### PR TITLE
fix: Show product sort only when all products shown

### DIFF
--- a/demo/content/kids.md
+++ b/demo/content/kids.md
@@ -180,6 +180,11 @@ main:
   title: Most popular for Kids
   limit: 10
   collectionref: products/collections/tops/_index.md
+- template: products
+  collection: tops
+  title: Most popular for Kids
+  limit: 4
+  collectionref: products/collections/tops/_index.md
 - template: content
   content: |-
     ## It Takes All Sorts: Kids’ Clothes at Reima

--- a/layouts/_default/collection.html
+++ b/layouts/_default/collection.html
@@ -57,8 +57,10 @@
 
       <!-- add filtering before products module -->
       {{ if eq .template "products" }}
+      <!-- only add in case no limit is imposed (i.e limit not defined, or limit greater than or equal to number of products -->
+      {{ $collectionPage := site.GetPage (printf "/collections/%s" .collection) }}
+      {{ if or (not .limit) (ge .limit (len $collectionPage.Pages)) }}
       <div class="grid__sort">
-        {{ $collectionPage := site.GetPage (printf "/collections/%s" .collection) }}
         {{ $numProducts := printf "<strong>%d</strong>" (len $collectionPage.Pages) }}
         <div>{{(default (printf "%s products" $numProducts) (T "Collection page number of products" $numProducts)) | safeHTML}}</div>
         <label for="">
@@ -81,6 +83,7 @@
           </svg>
         </label>
       </div>
+      {{ end }}
       {{ end }}
 
       {{ partial (printf "modules/%s" .template) . }}


### PR DESCRIPTION
Previously the product sorting dropdown was always shown on the collection pages. Now the dropdown is only shown when all products in the collection are visible. I.e. if there is a limit set (and that limit actually limits the number of products), the dropdown is not shown.

Closes #157