### PR TITLE
fix: Link product page reviews stars to review element

### DIFF
--- a/layouts/_default/baseof.css
+++ b/layouts/_default/baseof.css
@@ -115,6 +115,10 @@
   }
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   padding: 0;
   margin: 0;

--- a/layouts/partials/product.css
+++ b/layouts/partials/product.css
@@ -195,7 +195,7 @@
 /*
 We want to show the read more link under the contents when opened.
 That's why we set `display:contents` and then show the contents
-manually with CSS. The `[open]` attribute is still set on the 
+manually with CSS. The `[open]` attribute is still set on the
 `details` elements, so we can use that for styling.
 */
 
@@ -238,61 +238,57 @@ manually with CSS. The `[open]` attribute is still set on the
 /* styles applicable to all views */
 .tabs {
   border-bottom: var(--border);
+  margin: var(--block-margin);
 }
 
 .tabs ul {
   padding-left: 1rem;
 }
 
-/* mobile only styles */
-.tabs > details {
-  border-top: var(--border);
-  padding: 0 var(--content-padding);
+/* hide labels */
+.tab > label {
+  display: none;
 }
 
-.tabs > details > summary {
+/* ... but show the accordion label */
+.tab > label[for|=acc] {
   display: block;
   cursor: pointer;
   color: inherit;
+  border-top: var(--border);
   font-size: var(--text-font-size);
   font-weight: 700;
   padding: var(--content-padding);
-  margin: 0 calc(-1 * var(--content-padding));
 }
 
-.tabs > details[open] > summary {
+/* same for inputs */
+.tab > input {
+  display: none;
+}
+
+.tab > input[id|=acc] {
+  display: block;
+  position: absolute;
+  opacity: 0;
+}
+
+.tab > aside {
+  display: none;
+}
+
+.tab > input[name|=acc]:checked ~ label[for|=acc] {
   color: var(--color-bg);
   background: var(--color-fg);
 }
 
-.tabs > details > summary::-webkit-details-marker,
-.tabs > details > summary::marker {
-  display: none;
-  content: "";
-}
-
-/* add margins to first and last elements */
-.tabs > details > :nth-child(2) {
-  margin-top: var(--content-padding);
-}
-
-.tabs > details > :last-child {
-  margin-bottom: var(--content-padding);
-}
-
-/* hide "desktop" elements by default */
-.tabs > label,
-.tabs > aside,
-.tabs > input {
-  display: none;
+.tab > input[name|=acc]:checked ~ aside {
+  display: block;
+  padding: var(--content-padding)
+    max(var(--content-padding), (100% - var(--block-width)) / 2);
 }
 
 /* desktop styles */
 @media (min-width: 768px) {
-  .tabs > details {
-    display: none;
-  }
-
   .tabs {
     display: flex;
     flex-wrap: wrap;
@@ -302,13 +298,32 @@ manually with CSS. The `[open]` attribute is still set on the
     z-index: 0;
   }
 
-  .tabs > input {
+  /* remove .tab element from cssom to layout properly */
+  .tab {
+    display: contents;
+  }
+
+  /* hide asides possibly opened on mobile */
+  .tab > input[id|=acc]:checked ~ aside {
+    display: none;
+  }
+
+  /* hide and show appropriate labels and inputs */
+  .tab > input[id|=acc] {
+    display: none;
+  }
+
+  .tab > input {
     display: block;
     position: absolute;
     opacity: 0;
   }
 
-  .tabs > label {
+  .tab > label[for|=acc] {
+    display: none;
+  }
+
+  .tab > label {
     display: block;
     border: 1px solid var(--color-gray-light);
     border-top-left-radius: 2px;
@@ -321,11 +336,7 @@ manually with CSS. The `[open]` attribute is still set on the
     cursor: pointer;
   }
 
-  .tabs > aside {
-    display: none;
-  }
-
-  .tabs > input:checked + label + aside {
+  .tab > input[name=tab]:checked ~ aside {
     border-top: var(--border);
     width: 100%;
     order: 1;
@@ -338,21 +349,12 @@ manually with CSS. The `[open]` attribute is still set on the
       max(var(--content-padding), (100% - var(--block-width)) / 2);
   }
 
-  /* remove margins from first and last elements of grid */
-  .tabs > aside > * > :first-child {
-    margin-top: 0;
-  }
-
-  .tabs > aside > * > :last-child {
-    margin-bottom: 0;
-  }
-
   /* create the vertical line between grid items */
-  .tabs > aside > :nth-child(n+2) {
+  .tab > aside > :nth-child(n+2) {
     position: relative;
   }
 
-  .tabs > aside > :nth-child(n+2)::before {
+  .tab > aside > :nth-child(n+2)::before {
     content: "";
     position: absolute;
     top: 0;
@@ -361,11 +363,21 @@ manually with CSS. The `[open]` attribute is still set on the
     border-left: var(--border);
   }
 
-  .tabs input:focus + label {
+  /* remove margins from within the aside */
+  .tab > aside > * > :last-child {
+        margin-bottom: 0;
+  }
+
+  .tab > aside > * > :first-child {
+        margin-top: 0;
+  }
+
+  /* style label focus and checked states */
+  .tab > input[name=tab]:focus ~ label {
     outline: var(--focus-outline);
   }
 
-  .tabs input:checked + label {
+  .tab > input[name=tab]:checked ~ label {
     color: var(--color-text);
     border-color: var(--color-border);
     border-bottom-color: white;

--- a/layouts/partials/product.html
+++ b/layouts/partials/product.html
@@ -55,7 +55,9 @@
         {{ end }}
         {{ with partial "helpers/get-reviews-bottomline" $product.Params.yotpoId }}
         <div>
-          {{ range seq (math.Round .average) }}★{{ end }} {{ div (math.Round (mul .average 10)) 10 }} ({{.count}})
+          <a href="#reviews" class="silent-link">
+            {{ range seq (math.Round .average) }}★{{ end }} {{ div (math.Round (mul .average 10)) 10 }} ({{.count}})
+          </a>
         </div>
         {{ end }}
       </div>
@@ -177,74 +179,18 @@
 
 <section class="tabs">
   {{ range after 1 $productFields }}
-  {{ $field := trim (substr . 0 6) "[]" }}
-  {{ $contents := substr . 6 }}
-  <!-- tabs on >768w -->
-  <input type="radio" name="tab" id="{{$field}}" {{if eq $field "info"}}checked{{end}}>
-  <label for="{{$field}}">{{index $settings.accordion $field}}</label>
-  <aside>
-    <div>
-      {{$contents | safeHTML}}
-    </div>
-    <!-- if this is the info/features section, show tag-based features -->
-    {{ if eq $field "info" }}
-    <div class="features">
-      {{ range $product.Params.tags }}
-      {{ $tagData := split . ":" }}
-      {{ $tag := index $tagData 0 }}
-      {{ $value := index $tagData 1 }}
-      <!-- get feature for this tag if exists -->
-      {{ range where $settings.features "tag" $tag }}
-      {{ $modalid := .title }}
-      <!-- feature heading with modal link if modal exists -->
+  <div class="tab">
+    {{ $field := trim (substr . 0 6) "[]" }}
+    {{ $contents := substr . 6 }}
+    <!-- tabs -->
+    <input type="radio" name="tab" id="tab-{{$field}}" {{if eq $field "info"}}checked{{end}}>
+    <input type="checkbox" name="acc-{{$field}}" id="acc-{{$field}}">
+    <label for="tab-{{$field}}">{{index $settings.accordion $field}}</label>
+    <label for="acc-{{$field}}">{{index $settings.accordion $field}}</label>
+    <aside>
       <div>
-        <h3 class="features__heading">
-          {{ if .modal }}
-          <a href="#" openid="{{$modalid}}" class="silent-link">
-            {{.title}}
-          </a>
-          {{ else }}
-          {{.title}}
-          {{ end }}
-        </h3>
+        {{$contents | safeHTML}}
       </div>
-      <!-- modal if specified -->
-      {{ with .modal }}
-      <div class="modal" id="{{$modalid}}">
-        <div>
-          <button class="icon" close>
-            <svg>
-              <use xlink:href="#icon-close"></use>
-            </svg>
-          </button>
-          {{. | markdownify}}
-        </div>
-      </div>
-      {{ end }}
-      <!-- icons -->
-      {{ range .values }}
-      {{ $iconValue := .value }}
-      {{ with partial "helpers/get-image" .icon }}
-      {{ $svg := .Content }}
-      {{ if eq $iconValue $value }}
-      {{ $svg = replace $svg "<svg" "<svg class=\"active\"" }}
-      {{ end }}
-      {{$svg | safeHTML}}
-      {{ end }}
-      {{ end }}
-      <!-- tag description e.g. "Waterproof level 8000 mm" -->
-      <p>
-        {{ replace .description "VALUE" $value }}
-      </p>
-      {{ end }}
-      {{ end }}
-    </div>
-    {{ end }}
-  </aside>
-  <!-- tabs on "mobile" -->
-  <details>
-    <summary>{{index $settings.accordion $field}}</summary>
-      {{$contents | safeHTML}}
       <!-- if this is the info/features section, show tag-based features -->
       {{ if eq $field "info" }}
       <div class="features">
@@ -299,18 +245,21 @@
         {{ end }}
       </div>
       {{ end }}
-  </details>
+    </aside>
+  </div>
   {{ end }}
   {{ if $settings.reviews }}
-  <input type="radio" name="tab" id="reviews">
-  <label for="reviews">{{T "Reviews"}}</label>
-  <aside>
-    {{partial "product-reviews" $product}}
-  </aside>
-  <details>
-    <summary>{{T "Reviews"}}</summary>
-    {{partial "product-reviews" $product}}
-  </details>
+  <div class="tab">
+    <!-- we need a separate element for the anchor b/c .tab is display:content on desktop -->
+    <a id="reviews"></a>
+    <input type="radio" name="tab" id="tab-reviews">
+    <input type="checkbox" name="acc-reviews" id="acc-reviews">
+    <label for="tab-reviews">{{T "Reviews"}}</label>
+    <label for="acc-reviews">{{T "Reviews"}}</label>
+    <aside>
+      {{partial "product-reviews" $product}}
+    </aside>
+  </div>
   {{ end }}
 </section>
 

--- a/layouts/partials/product.ts
+++ b/layouts/partials/product.ts
@@ -41,20 +41,19 @@ form.addEventListener("submit", async (e) => {
   btn.disabled = true;
   try {
     const { variant } = targetForm.dataset;
-    const cart = document.querySelector<RCart>("r-cart");
-    await cart.addVariant(variant);
+    const cart = document.querySelector<RCart>("r-cart")!;
+    await cart.addVariant(variant!);
   } finally {
     btn.disabled = false;
   }
 });
 
 const renderPrice = (price: string) => {
-  /** @type {ProductPageProperties & Window} */
   const { priceTemplate } = window;
   return priceTemplate.replace("PRICE", price);
 };
 
-const getVariant = async (options: Options) =>
+const getVariant = (options: Options) =>
   variants.find((v) => {
     if (Object.keys(v.options).length !== Object.keys(options).length) {
       return false;
@@ -62,14 +61,14 @@ const getVariant = async (options: Options) =>
     return Object.keys(v.options).every((k) => options[k] === v.options[k]);
   });
 
-const inputChange = async (e: Event) => {
+const inputChange = (e: Event) => {
   const { name, value } = e.currentTarget as HTMLInputElement;
   const isColor = (e.currentTarget as HTMLElement).closest(
     ".selections--Color",
   );
   selectedOptions[name] = value;
   // check if available
-  const variant = await getVariant(selectedOptions);
+  const variant = getVariant(selectedOptions);
   if (!variant) {
     cartButton.innerText = cartButton.dataset.na!;
     cartButton.disabled = true;
@@ -82,13 +81,13 @@ const inputChange = async (e: Event) => {
     form.dataset.variant = variant.id;
   }
   // update availability
-  radioBoxes.forEach(async (radio) => {
+  radioBoxes.forEach((radio) => {
     const thisSelection = Object.assign(
       {},
       selectedOptions,
       { [radio.name]: radio.value },
     );
-    const thisVariant = await getVariant(thisSelection);
+    const thisVariant = getVariant(thisSelection);
     const thisLabel = document.querySelector(`label[for="${radio.id}"]`)!;
     if (thisVariant && thisVariant.available) {
       thisLabel.classList.remove("unavailable");
@@ -123,3 +122,20 @@ const inputChange = async (e: Event) => {
 radioBoxes.forEach((node) => {
   node.addEventListener("change", inputChange);
 });
+
+// open reviews when the review link is clicked
+const reviewsLink = document.querySelector('[href="#reviews"]');
+const openReviews = () => {
+  document.querySelectorAll('#acc-reviews, #tab-reviews').forEach((element) => {
+    (element as HTMLInputElement).checked = true;
+  });
+}
+
+if (reviewsLink) {
+  reviewsLink.addEventListener('click', () => {
+    openReviews();
+  });
+}
+
+// open reviews if initial load is for reviews
+if (location.hash === '#reviews') openReviews();


### PR DESCRIPTION
Now when clicking the review stars (next to the price), there is a scroll to the reviews element / tab (which is opened if closed).

Closes #139