### PR TITLE
fix: Add offset to anchor links

### DIFF
--- a/layouts/_default/baseof.css
+++ b/layouts/_default/baseof.css
@@ -119,11 +119,11 @@ html {
   scroll-behavior: smooth;
 }
 
-:target:before {
+:target::before {
   content: "";
   display: block;
-  height: 100px;
-  margin: -100px 0 0;
+  height: var(--menu-height);
+  margin: calc(var(--menu-height) * -1) 0 0;
 }
 
 body {

--- a/layouts/_default/baseof.css
+++ b/layouts/_default/baseof.css
@@ -119,6 +119,13 @@ html {
   scroll-behavior: smooth;
 }
 
+:target:before {
+  content: "";
+  display: block;
+  height: 100px;
+  margin: -100px 0 0;
+}
+
 body {
   padding: 0;
   margin: 0;


### PR DESCRIPTION
# Why?

Currently anchor links don't have any offset when scrolling to it.

# How?

Add offset to anchor links via CSS.

Closes #131




