### PR TITLE
fix: Align image links to center and increase image size

### DIFF
--- a/layouts/partials/modules/image-links-small.css
+++ b/layouts/partials/modules/image-links-small.css
@@ -6,8 +6,8 @@
 
 .module-image-links-small > div {
   display: grid;
-  justify-content: space-between;
-  grid-template-columns: repeat(auto-fit, 120px);
+  justify-content: center;
+  grid-template-columns: repeat(auto-fit, 158px);
   text-align: center;
-  gap: calc(var(--content-padding) / 2);
+  gap: 0.750rem;
 }

--- a/layouts/partials/modules/image-links-small.html
+++ b/layouts/partials/modules/image-links-small.html
@@ -9,8 +9,8 @@
       <!-- 
         fix image width to 120px
        -->
-        {{ $sizes := "120px" }}
-        {{ partial "img" (dict "image" .image "widths" "120,240" "sizes" $sizes) }}
+        {{ $sizes := "158px" }}
+        {{ partial "img" (dict "image" .image "widths" "158,316" "sizes" $sizes) }}
         {{ .title }}
       </a>
     </div>


### PR DESCRIPTION
# Why?

Subcategory link items should be aligned to center, not as space between. Subcategory images look pixelated, as if they’ve been upscaled.

# How?

Align Subcategory link items to center and and increase image size.

Closes #124