### PR TITLE
Add new product importer that downloads images from the media bank

### DIFF
--- a/importers/lib/files/filesystem.ts
+++ b/importers/lib/files/filesystem.ts
@@ -5,7 +5,7 @@ export type File = {
 
 export type Content = {
   path: string;
-  content: object;
+  content: unknown;
   markdown?: string;
 };
 
@@ -19,18 +19,22 @@ export type ContentAction = {
   content: Content;
 };
 
-export const serializeContent = (stringifier: (obj: object) => string) =>
+export const serializeContent = (
+  stringifier: (obj: unknown) => string,
+) =>
   (obj: Content): File => ({
     path: obj.path,
     data: `---\n${stringifier(obj.content)}\n---\n${obj.markdown || ""}`,
   });
 
-export const deserializeContent = (parser: (str: string) => unknown) =>
+export const deserializeContent = (
+  parser: (str: string) => Record<string, unknown>,
+) =>
   (file: File): Content => {
     const frontmatter = file.data.split("---")[1].trim();
     return {
       path: file.path,
-      content: parser(frontmatter) as object,
+      content: parser(frontmatter),
     };
   };
 
@@ -46,8 +50,8 @@ export const writeFileToDir = (dir: string) =>
 
 export const runContentAction = (
   dir: string,
-  stringifier: (obj: object) => string,
-): (contentAction: ContentAction) => Promise<any> => {
+  stringifier: (obj: unknown) => string,
+): (contentAction: ContentAction) => Promise<unknown> => {
   const writer = writeFileToDir(dir);
   const serializer = serializeContent(stringifier);
   return async (contentAction) => {
@@ -102,7 +106,7 @@ export const readFilesFromDir = (dir: string) =>
         path: file.path.replace(`${dir}/`, ""),
         data: file.data,
       }));
-    } catch (error) {
+    } catch (_error) {
       return [];
     }
   };

--- a/importers/products/domain.d.ts
+++ b/importers/products/domain.d.ts
@@ -18,6 +18,9 @@ type ProductNode = {
     pageInfo: {
       hasNextPage: boolean;
     };
+    edges: {
+      node: VariantNode;
+    }[];
   };
   images: {
     pageInfo: {
@@ -28,6 +31,8 @@ type ProductNode = {
     }[];
   };
 };
+
+type VariantNode = any;
 
 type ProductImageNode = {
   originalSrc: string;

--- a/importers/products/product-generator.ts
+++ b/importers/products/product-generator.ts
@@ -108,6 +108,7 @@ const query = (count: number, cursor?: string) =>
               availableForSale
               compareAtPrice
               price
+              sku
               image { originalSrc }
               selectedOptions {
                 name

--- a/importers/products/write-products.ts
+++ b/importers/products/write-products.ts
@@ -60,6 +60,14 @@ export const writeProduct = (
       .then(transform(checkMissingVariants))
       .then(transform(getResources))
       .then(transform(mapProductLegacy))
+      // add sku to variants in a very hacky way
+      .then(({ productNode, product }: TransformerParam) => ({
+        productNode,
+        product: {
+          ...product,
+          variants: product.variants.map((v: any, i: number) => ({ ...v, sku: productNode.variants.edges[i].node.sku }))
+        }
+      }))
       // collections are needed for the algolia index
       .then(transform(addCollections))
       .then(toContent)

--- a/importers/shopify/README.md
+++ b/importers/shopify/README.md
@@ -1,0 +1,11 @@
+# Shopify importer
+
+Deno scripts used for importing products and collections from Shopify and product images from the media bank into a format that the Hugo site understands.
+
+## Usage
+
+Run the main `cmd.ts` with Deno to see usage instructions (`deno run cmd.ts`).
+
+## Details
+
+The Shopify configuration is picked up from the `config.yml` file. See the source code for more information, it is much easier to keep documentation in sync there.

--- a/importers/shopify/cmd.ts
+++ b/importers/shopify/cmd.ts
@@ -1,7 +1,8 @@
+import { parse as parseYaml } from "https://deno.land/std@0.97.0/encoding/yaml.ts";
+import { grantOrThrow } from "https://deno.land/std@0.97.0/permissions/mod.ts";
+import { log, parseFlags } from "./deps.ts";
+import type { LevelName } from "./deps.ts";
 import { importProductsAndMediaBankImages } from "./products.ts";
-
-// countStr is used for development; it limits the number of products and collections fetched
-const [outDir, countStr] = Deno.args;
 
 const usage = `
 Import products and collections from Shopify and product images from the media bank into a format that the Hugo site understands.
@@ -9,20 +10,81 @@ Import products and collections from Shopify and product images from the media b
 Shopify configuration is read from config.yml.
 
 Usage:
-> deno run cmd.ts [directory]
+> deno run cmd.ts DIRECTORY [OPTIONS]
+
+Options:
+  -v        Verbose logging (DEBUG)
+  -c COUNT  Only download the first COUNT products
 `;
 
-if (!outDir) {
+const { _: [outDir], ...flags } = parseFlags(Deno.args);
+
+let logLevel: LevelName = "INFO";
+if (flags.v) logLevel = "DEBUG";
+
+await log.setup({
+  handlers: {
+    console: new log.handlers.ConsoleHandler("DEBUG"),
+  },
+  loggers: {
+    default: {
+      level: logLevel,
+      handlers: ["console"],
+    },
+  },
+});
+
+const logger = log.getLogger();
+
+export type ShopifyConfig = {
+  store: string;
+  token: string;
+};
+
+type HugoConfig = {
+  params?: {
+    public?: {
+      shopify?: {
+        store?: string;
+        token?: string;
+      };
+    };
+  };
+} | null;
+
+const getShopConfig = (hugoConfigYaml: string) => {
+  const config = parseYaml(hugoConfigYaml) as HugoConfig;
+  const { store, token } = config?.params?.public?.shopify || {};
+  if (!store || !token) throw new Error("No shop and/or token found in config");
+  return { store, token };
+};
+
+let shopifyConfig: { store: string; token: string };
+
+try {
+  logger.info("Checking arguments and permissions");
+  if (!outDir) {
+    throw new Error("Out directory not specified");
+  }
+  grantOrThrow({ name: "read", path: "config.yml" });
+  const hugoConfigYaml = await Deno.readTextFile("config.yml");
+  shopifyConfig = getShopConfig(hugoConfigYaml);
+  grantOrThrow(
+    { name: "net", host: `${shopifyConfig.store}.myshopify.com` },
+    { name: "net", host: "reima.mediabank.fi" },
+    { name: "write", path: outDir as string },
+    { name: "read", path: outDir as string },
+  );
+} catch (_error) {
   console.log(usage);
   Deno.exit(1);
 }
 
-let count;
-if (countStr) {
-  count = Number.parseInt(countStr);
-}
+await importProductsAndMediaBankImages(
+  logger,
+  `${outDir}/products`,
+  shopifyConfig,
+  flags.c,
+);
 
-const hugoConfigYaml = await Deno.readTextFile("config.yml");
-
-await importProductsAndMediaBankImages(outDir, hugoConfigYaml, count);
-console.warn("WARNING! collections are currently not supported");
+logger.warning("Collections are currently not supported");

--- a/importers/shopify/cmd.ts
+++ b/importers/shopify/cmd.ts
@@ -1,0 +1,28 @@
+import { importProductsAndMediaBankImages } from "./products.ts";
+
+// countStr is used for development; it limits the number of products and collections fetched
+const [outDir, countStr] = Deno.args;
+
+const usage = `
+Import products and collections from Shopify and product images from the media bank into a format that the Hugo site understands.
+
+Shopify configuration is read from config.yml.
+
+Usage:
+> deno run cmd.ts [directory]
+`;
+
+if (!outDir) {
+  console.log(usage);
+  Deno.exit(1);
+}
+
+let count;
+if (countStr) {
+  count = Number.parseInt(countStr);
+}
+
+const hugoConfigYaml = await Deno.readTextFile("config.yml");
+
+await importProductsAndMediaBankImages(outDir, hugoConfigYaml, count);
+console.warn("WARNING! collections are currently not supported");

--- a/importers/shopify/deps.ts
+++ b/importers/shopify/deps.ts
@@ -1,0 +1,4 @@
+export { exists } from "https://deno.land/std@0.84.0/fs/exists.ts";
+export { log } from "../lib/fn/mod.ts";
+export * from "../lib/files/mod.ts";
+export * from "../lib/lazy-list/mod.ts";

--- a/importers/shopify/deps.ts
+++ b/importers/shopify/deps.ts
@@ -1,4 +1,10 @@
+export { grantOrThrow } from "https://deno.land/std@0.97.0/permissions/mod.ts";
+export * as log from "https://deno.land/std@0.97.0/log/mod.ts";
+export type {
+  LevelName,
+  Logger,
+} from "https://deno.land/std@0.97.0/log/mod.ts";
+export { parse as parseFlags } from "https://deno.land/std@0.97.0/flags/mod.ts";
 export { exists } from "https://deno.land/std@0.84.0/fs/exists.ts";
-export { log } from "../lib/fn/mod.ts";
 export * from "../lib/files/mod.ts";
 export * from "../lib/lazy-list/mod.ts";

--- a/importers/shopify/products.ts
+++ b/importers/shopify/products.ts
@@ -72,7 +72,7 @@ export const importProductsAndMediaBankImages = async (
 
   const writeProduct = getProductWriter(outDir, getCurrencyFormatter("en-US"));
 
-  if (limit) logger.info(`Limiting import to ${limit} products`);
+  if (limit) logger.warning(`Limiting import to ${limit} products`);
   let count = 0;
 
   const allProductHandles: string[] = [];
@@ -84,8 +84,9 @@ export const importProductsAndMediaBankImages = async (
 
     const dir = `${outDir}/${productNode.handle}`;
     const downloadImages = downloadSkuImages(dir, logger);
-    for (const { node } of productNode.variants.edges) {
-      await downloadImages(node.sku);
+    for (let i = 0; i < productNode.variants.edges.length; i++) {
+      const v = productNode.variants.edges[i].node;
+      await downloadImages(v.sku, i);
     }
 
     allProductHandles.push(productNode.handle);

--- a/importers/shopify/products.ts
+++ b/importers/shopify/products.ts
@@ -1,0 +1,89 @@
+import {
+  parse,
+  stringify,
+} from "https://deno.land/std@0.97.0/encoding/yaml.ts";
+import {
+  createProductGenerator,
+  ProductNode,
+} from "./products/product-generator.ts";
+import { Content, serializeContent, writeFileToDir } from "./deps.ts";
+import {
+  CurrencyFormatter,
+  mapProduct,
+  Product,
+} from "./products/product-mapper.ts";
+import { downloadSkuImages } from "./products/product-image-downloader.ts";
+
+type ProductWriter = (product: ProductNode) => Promise<void>;
+
+const toContent = ({ descriptionHtml, ...product }: Product): Content => ({
+  path: `${product.handle}/index.html`,
+  content: product,
+  markdown: descriptionHtml,
+});
+
+const serializer = (obj: unknown) =>
+  stringify(obj as Record<string, unknown>, { skipInvalid: true });
+
+const getProductWriter = (
+  outDir: string,
+  currencyFormatter: CurrencyFormatter,
+): ProductWriter => {
+  return (productNode) =>
+    Promise.resolve(productNode)
+      .then(mapProduct(currencyFormatter))
+      .then(toContent)
+      .then(serializeContent(serializer))
+      .then(writeFileToDir(outDir));
+};
+
+type HugoConfig = {
+  params?: {
+    public?: {
+      shopify?: {
+        store?: string;
+        token?: string;
+      };
+    };
+  };
+} | null;
+
+const getShopConfig = (hugoConfigYaml: string) => {
+  const config = parse(hugoConfigYaml) as HugoConfig;
+  const { store, token } = config?.params?.public?.shopify || {};
+  if (!store || !token) throw new Error("No shop and/or token found in config");
+  return { shop: store, token };
+};
+
+const getCurrencyFormatter = (locale: string): CurrencyFormatter =>
+  (currency: string) =>
+    (value: number | string) => {
+      const valueNumber = typeof value === "number"
+        ? value
+        : Number.parseFloat(value);
+      const formatter = Intl.NumberFormat(locale, {
+        style: "currency",
+        currency,
+      });
+      return formatter.format(valueNumber);
+    };
+
+export const importProductsAndMediaBankImages = async (
+  outDir: string,
+  hugoConfigYaml: string,
+  limit?: number,
+) => {
+  const writeProduct = getProductWriter(outDir, getCurrencyFormatter("en-US"));
+  const shopConfig = getShopConfig(hugoConfigYaml);
+  let count = 0;
+  for await (const productNode of createProductGenerator(shopConfig)) {
+    count++;
+    const dir = `${outDir}/${productNode.handle}/imgs`;
+    await writeProduct(productNode);
+    const downloadImages = downloadSkuImages(dir);
+    for (const { node } of productNode.variants.edges) {
+      await downloadImages(node.sku);
+    }
+    if (limit && count >= limit) break;
+  }
+};

--- a/importers/shopify/products/product-generator.ts
+++ b/importers/shopify/products/product-generator.ts
@@ -1,9 +1,13 @@
-type ProductGeneratorOptions = { shop: string; token: string };
+import type { ShopifyConfig } from "../cmd.ts";
+import type { Logger } from "../deps.ts";
+
+type ProductGeneratorOptions = ShopifyConfig;
 
 export async function* createProductGenerator(
-  { shop, token }: ProductGeneratorOptions,
+  { store, token }: ProductGeneratorOptions,
+  logger?: Logger,
 ): AsyncGenerator<ProductNode> {
-  const url = `https://${shop}.myshopify.com/api/2021-01/graphql.json`;
+  const url = `https://${store}.myshopify.com/api/2021-01/graphql.json`;
   const headers = {
     "X-Shopify-Storefront-Access-Token": token,
     "Content-Type": "application/graphql",
@@ -27,12 +31,8 @@ export async function* createProductGenerator(
     }
     const { products: { edges: { length } } } = data;
     const elapsed = (Date.now() - startTime);
-    console.log(
-      "Got",
-      length,
-      "products from Shopify, average",
-      Math.round(elapsed / length),
-      "ms per product",
+    logger && logger.info(
+      `Got ${length} products from Shopify, average ${Math.round(elapsed / length)} ms per product`,
     );
     for (const edge of data.products.edges) {
       if (edge.node.variants.pageInfo.hasNextPage) {

--- a/importers/shopify/products/product-generator.ts
+++ b/importers/shopify/products/product-generator.ts
@@ -1,0 +1,181 @@
+type ProductGeneratorOptions = { shop: string; token: string };
+
+export async function* createProductGenerator(
+  { shop, token }: ProductGeneratorOptions,
+): AsyncGenerator<ProductNode> {
+  const url = `https://${shop}.myshopify.com/api/2021-01/graphql.json`;
+  const headers = {
+    "X-Shopify-Storefront-Access-Token": token,
+    "Content-Type": "application/graphql",
+    "Accept": "application/json",
+  };
+  let hasNextPage: boolean;
+  let cursor: string | undefined;
+  do {
+    const startTime = Date.now();
+    const response = await fetch(
+      url,
+      { method: "POST", headers, body: query(5, cursor) },
+    );
+    if (!response.ok) {
+      throw new Error(`Could not query, status code ${response.status}`);
+    }
+    const { data, errors } = await response.json() as ProductQueryResult;
+    if (!data) {
+      if (errors) console.error(errors);
+      throw new Error("Could not get product data");
+    }
+    const { products: { edges: { length } } } = data;
+    const elapsed = (Date.now() - startTime);
+    console.log(
+      "Got",
+      length,
+      "products from Shopify, average",
+      Math.round(elapsed / length),
+      "ms per product",
+    );
+    for (const edge of data.products.edges) {
+      if (edge.node.variants.pageInfo.hasNextPage) {
+        throw new Error(`Product ${edge.node.handle} has more variants`);
+      }
+      yield edge.node;
+      cursor = edge.cursor;
+    }
+    hasNextPage = data.products.pageInfo.hasNextPage;
+  } while (hasNextPage);
+}
+
+const getPagination = (count: number, cursor?: string) => {
+  let pagination = `first: ${count}`;
+  if (cursor) {
+    pagination += `, after: "${cursor}"`;
+  }
+  return pagination;
+};
+
+const query = (count: number, cursor?: string) => `
+{
+  products(${getPagination(count, cursor)}) {
+    pageInfo {
+      hasNextPage
+    }
+    edges {
+      cursor
+      node {
+        id
+        handle
+        title
+        availableForSale
+        descriptionHtml
+        description
+        collections(first: 100) {
+          edges {
+            node {
+              handle
+            }
+          }
+        }
+        tags
+        priceRange {
+          minVariantPrice { amount, currencyCode }
+          maxVariantPrice { amount }
+        }
+        compareAtPriceRange {
+          maxVariantPrice { amount, currencyCode }
+        }
+        options {
+          name
+          values
+        }
+        variants(first: 100) {
+          pageInfo {
+            hasNextPage
+          }
+          edges {
+            node {
+              id
+              availableForSale
+              compareAtPrice
+              price
+              sku
+              selectedOptions {
+                name
+                value
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`;
+
+type Decimal = string;
+
+type Money = {
+  amount: Decimal;
+  currencyCode?: string;
+};
+
+export type ProductNode = {
+  id: string;
+  handle: string;
+  title: string;
+  availableForSale: boolean;
+  descriptionHtml: string;
+  description: string;
+  collections: {
+    edges: {
+      node: {
+        handle: string;
+      };
+    }[];
+  };
+  tags: string[];
+  priceRange: {
+    minVariantPrice: Money;
+    maxVariantPrice: Money;
+  };
+  compareAtPriceRange: {
+    maxVariantPrice: Money;
+  };
+  options: {
+    name: string;
+    values: string[];
+  }[];
+  variants: {
+    pageInfo: {
+      hasNextPage: boolean;
+    };
+    edges: VariantEdge[];
+  };
+};
+
+export type VariantEdge = {
+  node: {
+    id: string;
+    availableForSale: boolean;
+    compareAtPrice: string;
+    price: string;
+    sku: string;
+    selectedOptions: {
+      name: string;
+      value: string;
+    }[];
+  };
+};
+type ProductQueryResult = {
+  data?: {
+    products: {
+      pageInfo: { hasNextPage: boolean };
+      edges: {
+        cursor: string;
+        node: ProductNode;
+      }[];
+    };
+  };
+  errors?: {
+    message: string;
+  }[];
+};

--- a/importers/shopify/products/product-image-downloader.ts
+++ b/importers/shopify/products/product-image-downloader.ts
@@ -1,0 +1,65 @@
+import parse from "https://denopkg.com/nekobato/deno-xml-parser/index.ts";
+import { ParsedSku, parseSku } from "./sku-parser.ts";
+
+type Unwrap<T> = T extends Promise<infer U> ? U : T;
+
+const downloadMediaBankXml = async (productNumber: string) => {
+  try {
+    const response = await fetch(
+      `https://reima.mediabank.fi/fi/extension/onesite/xml/${productNumber}`,
+    );
+    if (!response.ok) throw new Error(`Response ${response.status}`);
+    return {
+      product: productNumber,
+      xml: await response.text(),
+    };
+  } catch (e) {
+    console.error("Could not download product", productNumber);
+    throw e;
+  }
+};
+
+type Image = {
+  product: string;
+  name: string;
+  url: string;
+};
+
+const xmlToImages = (
+  doc: Unwrap<ReturnType<typeof downloadMediaBankXml>>,
+): Image[] | undefined => {
+  const xml = parse(doc.xml);
+  return xml.root?.children.map((element, i) => ({
+    product: doc.product,
+    name: `${i.toString().padStart(2, "0")}-${element.attributes.name}`,
+    url: element.attributes.url,
+  }));
+};
+
+const downloadImagesParallel = (dir: string) =>
+  async (
+    images: Unwrap<ReturnType<typeof xmlToImages>>,
+  ): Promise<void> => {
+    await Promise.all(
+      images?.map(async (image) => {
+        const data = (await fetch(image.url)).arrayBuffer();
+        Deno.mkdir(dir, { recursive: true });
+        return Deno.writeFile(
+          `${dir}/${image.name}`,
+          new Uint8Array(await data),
+        );
+      }) || [],
+    );
+  };
+
+const skuToMediaBankProductNumber = (sku: ParsedSku) =>
+  `${sku.product}-${sku.color}`;
+
+export const downloadSkuImages = (dir: string) =>
+  (sku: string) =>
+    Promise.resolve(sku)
+      .then(parseSku)
+      .then(skuToMediaBankProductNumber)
+      .then(downloadMediaBankXml)
+      .then(xmlToImages)
+      .then(downloadImagesParallel(dir));

--- a/importers/shopify/products/product-image-downloader.ts
+++ b/importers/shopify/products/product-image-downloader.ts
@@ -1,5 +1,8 @@
+import { exists } from "https://deno.land/std@0.97.0/fs/exists.ts";
+import { dirname, join } from "https://deno.land/std@0.97.0/path/mod.ts";
 import parse from "https://denopkg.com/nekobato/deno-xml-parser/index.ts";
 import { ParsedSku, parseSku } from "./sku-parser.ts";
+import type { Logger } from "../deps.ts";
 
 type Unwrap<T> = T extends Promise<infer U> ? U : T;
 
@@ -25,41 +28,79 @@ type Image = {
   url: string;
 };
 
+type ImageWithPath = Image & {
+  path: string;
+};
+
+const ensureDir = async (path: string) => {
+  await Deno.mkdir(dirname(path), { recursive: true });
+};
+
 const xmlToImages = (
   doc: Unwrap<ReturnType<typeof downloadMediaBankXml>>,
-): Image[] | undefined => {
+): Image[] => {
   const xml = parse(doc.xml);
   return xml.root?.children.map((element, i) => ({
     product: doc.product,
     name: `${i.toString().padStart(2, "0")}-${element.attributes.name}`,
     url: element.attributes.url,
-  }));
+  })) || [];
 };
 
-const downloadImagesParallel = (dir: string) =>
+const addPath = (dir: string) =>
+  (images: Image[]): ImageWithPath[] =>
+    images.map((img) => ({ ...img, path: join(dir, "imgs", img.name) }));
+
+const removeExistingImages = (logger?: Logger) =>
+  async (images: ImageWithPath[]): Promise<ImageWithPath[]> => {
+    const existingUndef = await Promise.all(images.map(async (img) => {
+      await ensureDir(img.path);
+      if (await exists(img.path)) {
+        logger &&
+          logger.debug(`Image ${img.path} already exists, skipping download`);
+        return undefined;
+      }
+      return img;
+    }));
+    return existingUndef.filter(Boolean) as ImageWithPath[];
+  };
+
+const downloadImagesParallel = (logger?: Logger) =>
   async (
-    images: Unwrap<ReturnType<typeof xmlToImages>>,
+    images: ImageWithPath[],
   ): Promise<void> => {
+    if (!images.length) {
+      logger && logger.debug("No images to download");
+      return;
+    }
+    logger &&
+      logger.debug(`Downloading ${images.length} for ${images[0].product}`);
     await Promise.all(
-      images?.map(async (image) => {
+      images.map(async (image) => {
         const data = (await fetch(image.url)).arrayBuffer();
-        Deno.mkdir(dir, { recursive: true });
+        await ensureDir(image.path);
         return Deno.writeFile(
-          `${dir}/${image.name}`,
+          image.path,
           new Uint8Array(await data),
         );
-      }) || [],
+      }),
     );
   };
 
 const skuToMediaBankProductNumber = (sku: ParsedSku) =>
   `${sku.product}-${sku.color}`;
 
-export const downloadSkuImages = (dir: string) =>
+export const downloadSkuImages = (dir: string, logger?: Logger) =>
   (sku: string) =>
     Promise.resolve(sku)
+      .then((sku: string) => {
+        logger && logger.debug(`Downloading images for ${sku}`);
+        return sku;
+      })
       .then(parseSku)
       .then(skuToMediaBankProductNumber)
       .then(downloadMediaBankXml)
       .then(xmlToImages)
-      .then(downloadImagesParallel(dir));
+      .then(addPath(dir))
+      .then(removeExistingImages(logger))
+      .then(downloadImagesParallel(logger));

--- a/importers/shopify/products/product-mapper.ts
+++ b/importers/shopify/products/product-mapper.ts
@@ -1,4 +1,5 @@
 import type { ProductNode, VariantEdge } from "./product-generator.ts";
+import { parseSku } from "./sku-parser.ts";
 
 export type Product = {
   handle: string;
@@ -38,6 +39,8 @@ type Variant = {
   compareAtPrice?: number;
   compareAtPriceFormatted?: string;
   options: Record<string, string>;
+  sku: string;
+  productAndColor: string;
 };
 
 const transform = <
@@ -112,6 +115,11 @@ const addCollections = (p: ProductNode) => ({
 
 const addFiltering = () => ({ filtering: {} });
 
+const getProductAndColor = (sku: string) => {
+  const parsedSku = parseSku(sku);
+  return `${parsedSku.product}-${parsedSku.color}`;
+};
+
 const addVariants = (formatted: CurrencyFormatter) =>
   (p: ProductNode): Pick<Product, "variants"> => ({
     variants: p.variants.edges.map(({ node: variant }) => {
@@ -133,6 +141,8 @@ const addVariants = (formatted: CurrencyFormatter) =>
           ...obj,
           [opt.name]: opt.value,
         }), {}),
+        sku: variant.sku,
+        productAndColor: getProductAndColor(variant.sku),
       };
     }) || [],
   });

--- a/importers/shopify/products/product-mapper.ts
+++ b/importers/shopify/products/product-mapper.ts
@@ -1,0 +1,200 @@
+import type { ProductNode, VariantEdge } from "./product-generator.ts";
+
+export type Product = {
+  handle: string;
+  collections: string[];
+  title: string;
+  tags: string[];
+  price: number;
+  priceFormatted: string;
+  compareAtPrice?: number;
+  compareAtPriceFormatted?: string;
+  hasPriceRange: boolean;
+  available: boolean;
+  filtering: Record<string, string[]>;
+  options: Option[];
+  variants: Variant[];
+  description: string;
+  descriptionHtml: string;
+  yotpoId?: string;
+};
+
+type Option = {
+  name: string;
+  firstAvailable: string;
+  values: OptionValue[];
+};
+
+type OptionValue = {
+  value: string;
+  firstAvailable: boolean;
+  availableInitially: boolean;
+};
+
+type Variant = {
+  id: string;
+  available: boolean;
+  price: number;
+  compareAtPrice?: number;
+  compareAtPriceFormatted?: string;
+  options: Record<string, string>;
+};
+
+const transform = <
+  R extends Partial<Product>,
+  P extends Partial<Product>,
+>(
+  transformer: (
+    poductNode: ProductNode,
+    product: Partial<Product>,
+  ) => R | Promise<R>,
+) =>
+  async (
+    { productNode, product }: {
+      productNode: ProductNode;
+      product: P;
+    },
+  ) => ({
+    productNode,
+    product: {
+      ...product,
+      ...(await transformer(productNode, product)),
+    },
+  });
+
+const addScalars = (p: ProductNode) => ({
+  handle: p.handle,
+  title: p.title,
+  available: p.availableForSale,
+  description: p.description,
+  descriptionHtml: p.descriptionHtml,
+  tags: p.tags,
+});
+
+const addMinPriceAsPrice = (p: ProductNode) => {
+  const price = Number.parseFloat(p.priceRange.minVariantPrice.amount);
+  const formatter = Intl.NumberFormat("en-US", {
+    currency: p.priceRange.minVariantPrice.currencyCode,
+    style: "currency",
+  });
+  return {
+    price,
+    priceFormatted: formatter.format(price),
+  };
+};
+
+const addHasPriceRange = (p: ProductNode) => ({
+  hasPriceRange: Number.parseFloat(p.priceRange.maxVariantPrice.amount) >
+    Number.parseFloat(p.priceRange.minVariantPrice.amount),
+});
+
+const addCompareAtPrice = (p: ProductNode) => {
+  const compareAtPrice = Number.parseFloat(
+    p.compareAtPriceRange.maxVariantPrice.amount,
+  );
+  const formatter = Intl.NumberFormat("en-US", {
+    currency: p.compareAtPriceRange.maxVariantPrice.currencyCode,
+    style: "currency",
+  });
+  return {
+    compareAtPrice,
+    compareAtPriceFormatted: formatter.format(compareAtPrice),
+  };
+};
+
+const addCollections = (p: ProductNode) => ({
+  collections: p.collections.edges.map(({ node }) => node.handle),
+});
+
+const addFiltering = () => ({ filtering: {} });
+
+const addVariants = (formatted: CurrencyFormatter) =>
+  (p: ProductNode): Pick<Product, "variants"> => ({
+    variants: p.variants.edges.map(({ node: variant }) => {
+      return {
+        id: variant.id,
+        available: variant.availableForSale,
+        price: Number.parseFloat(variant.price),
+        priceFormatted: formatted(
+          p.priceRange.minVariantPrice.currencyCode || "",
+        )(variant.price),
+        compareAtPrice: variant.compareAtPrice
+          ? Number.parseFloat(variant.compareAtPrice)
+          : undefined,
+        compareAtPriceFormatted: variant.compareAtPrice &&
+          formatted(p.priceRange.minVariantPrice.currencyCode || "")(
+            variant.compareAtPrice,
+          ),
+        options: variant.selectedOptions.reduce((obj, opt) => ({
+          ...obj,
+          [opt.name]: opt.value,
+        }), {}),
+      };
+    }) || [],
+  });
+
+const addOptions = (p: ProductNode): Pick<Product, "options"> => {
+  const findVariant = (
+    variants: VariantEdge[],
+    options: { [option: string]: string },
+  ) => {
+    const variant = variants.find(({ node: v }) => {
+      if (Object.keys(options).length !== v.selectedOptions.length) {
+        return false;
+      }
+      return v.selectedOptions.every((opt) => options[opt.name] === opt.value);
+    }) || undefined;
+    return variant?.node;
+  };
+  const allOptionsObj = p.variants.edges.reduce((obj, { node: variant }) => {
+    let newObj = obj;
+    variant.selectedOptions.forEach((opt) => {
+      const allOptionValues = obj[opt.name] || [];
+      if (!allOptionValues.includes(opt.value)) allOptionValues.push(opt.value);
+      newObj = { ...newObj, [opt.name]: allOptionValues };
+    });
+    return newObj;
+  }, {} as Record<string, string[]>);
+  const firstAvailableVariant = p.variants.edges.find(
+    ({ node: variant }) => variant.availableForSale,
+  )?.node;
+  const firstAvailableVariantOptionsObj = (firstAvailableVariant &&
+    firstAvailableVariant.selectedOptions.reduce(
+      (obj, opt) => ({ ...obj, [opt.name]: opt.value }),
+      {} as Record<string, string>,
+    )) || {};
+  const options = Object.entries(allOptionsObj).map(
+    ([name, values]) => ({
+      name,
+      firstAvailable: firstAvailableVariantOptionsObj[name],
+      values: values.map((value) => ({
+        value,
+        firstAvailable: firstAvailableVariantOptionsObj[name] === value,
+        availableInitially: findVariant(
+          p.variants.edges,
+          { ...firstAvailableVariantOptionsObj, [name]: value },
+        )?.availableForSale || false,
+      })),
+    }),
+  );
+  return { options };
+};
+
+export type CurrencyFormatter = (
+  currency: string,
+) => (price: string | number) => string;
+
+export const mapProduct = (currencyFormatter: CurrencyFormatter) =>
+  (
+    productNode: ProductNode,
+  ): Promise<Product> =>
+    Promise.resolve({ productNode, product: {} })
+      .then(transform(addScalars))
+      .then(transform(addMinPriceAsPrice))
+      .then(transform(addCompareAtPrice))
+      .then(transform(addHasPriceRange))
+      .then(transform(addCollections))
+      .then(transform(addFiltering))
+      .then(transform(addVariants(currencyFormatter)))
+      .then(transform(addOptions))
+      .then(({ product }: { product: Product }) => product);

--- a/importers/shopify/products/product-mapper.ts
+++ b/importers/shopify/products/product-mapper.ts
@@ -16,7 +16,7 @@ export type Product = {
   variants: Variant[];
   description: string;
   descriptionHtml: string;
-  yotpoId?: string;
+  yotpoId: string;
 };
 
 type Option = {
@@ -62,6 +62,9 @@ const transform = <
     },
   });
 
+const convertToLegacyId = (id: string): string =>
+  atob(id).split("/").pop() as string;
+
 const addScalars = (p: ProductNode) => ({
   handle: p.handle,
   title: p.title,
@@ -69,6 +72,7 @@ const addScalars = (p: ProductNode) => ({
   description: p.description,
   descriptionHtml: p.descriptionHtml,
   tags: p.tags,
+  yotpoId: convertToLegacyId(p.id),
 });
 
 const addMinPriceAsPrice = (p: ProductNode) => {

--- a/importers/shopify/products/sku-parser.test.ts
+++ b/importers/shopify/products/sku-parser.test.ts
@@ -1,0 +1,20 @@
+import parseSku from "./sku-parser.ts";
+import { assertEquals } from "https://deno.land/std@0.97.0/testing/asserts.ts";
+
+Deno.test("regular product numbers work", () => {
+  const result = parseSku("1234564321000");
+  assertEquals(result.product, "123456");
+  assertEquals(result.color, "4321");
+});
+
+Deno.test("product numbers with letters work", () => {
+  const result = parseSku("123456A4321000");
+  assertEquals(result.product, "123456A");
+  assertEquals(result.color, "4321");
+});
+
+Deno.test("product numbers with letters work", () => {
+  const result = parseSku("599154B7250000");
+  assertEquals(result.product, "599154B");
+  assertEquals(result.color, "7250");
+});

--- a/importers/shopify/products/sku-parser.ts
+++ b/importers/shopify/products/sku-parser.ts
@@ -1,0 +1,18 @@
+export type ParsedSku = {
+  product: string;
+  color: string;
+  size: string;
+};
+
+export const parseSku = (sku: string): ParsedSku => {
+  const match = sku.match(/^(\d{6}[a-zA-Z]?)(.{4})(.*)$/);
+  if (!match) throw new Error(`Could not parse sku ${sku}`);
+  const [, product, color, size] = match;
+  return {
+    product,
+    color,
+    size,
+  };
+};
+
+export default parseSku;

--- a/importers/shopify/products/write-products.test.ts
+++ b/importers/shopify/products/write-products.test.ts
@@ -1,0 +1,9 @@
+import { assertEquals } from "https://deno.land/std@0.81.0/testing/asserts.ts";
+import { convertToLegacyId } from "./write-products.ts";
+
+Deno.test("legacy id converter", () => {
+  assertEquals(
+    convertToLegacyId("Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0LzE5NzQyMDgyOTkwMzA="),
+    "1974208299030",
+  );
+});

--- a/importers/shopify/products/write-products.ts
+++ b/importers/shopify/products/write-products.ts
@@ -1,0 +1,57 @@
+import { Content, serializeContent, writeFileToDir } from "../deps.ts";
+import { mapProductLegacy } from "./write-products-legacy.ts";
+import type { ProductNode } from "./product-generator.ts";
+
+type Product = {
+  handle: string
+  title: string
+}
+
+export const convertToLegacyId = (id: string) => atob(id).split("/").pop();
+
+const toContent = ({ source: productNode, target: product }: {source: ProductNode, target: Product}): Content => ({
+  path: `${product.handle}/index.html`,
+  content: product,
+  markdown: productNode.descriptionHtml,
+});
+
+const serializer = (obj: Record<string, unknown>) => JSON.stringify(obj, undefined, 2);
+
+type Obj = Record<string, unknown>
+
+const transform = <S extends unknown, R extends Obj>(transformer: (input: S) => R | Promise<R>) =>
+  async <T extends Obj>({ source, target }: { source: S, target: T}) => ({
+    source,
+    target: {
+      ...target,
+      ...(await transformer(source))
+    },
+  });
+
+const addCollections= (product: ProductNode) => ({
+  collections: product.collections.edges.map(({ node }) => node.handle),
+});
+
+export const writeProduct = (
+  outDir: string,
+) => {
+  return (productNode: ProductNode): Promise<void> =>
+    Promise.resolve({ source: productNode, target: {} })
+      .then(transform(mapProductLegacy))
+      // add sku to variants in a very hacky way
+      .then(({ source: productNode, target: product }: any) => ({
+        source: productNode,
+        target: {
+          ...product,
+          variants: product.variants.map((v: any, i: number) => ({
+            ...v,
+            sku: productNode.variants.edges[i].node.sku,
+          })),
+        },
+      }))
+      // collections are needed for the algolia index
+      .then(transform(addCollections))
+      .then(toContent)
+      .then(serializeContent(serializer))
+      .then(writeFileToDir(outDir));
+};

--- a/layouts/partials/elements/r-thumbnails.ts
+++ b/layouts/partials/elements/r-thumbnails.ts
@@ -1,10 +1,18 @@
-import RCarousel from './r-carousel.ts'
+import type RCarousel from "./r-carousel.ts";
 
 export default class RThumbnails extends HTMLElement {
-  carouselScrolling: number = 0;
+  carouselScrolling = 0;
+  carouselElement: RCarousel;
+
+  constructor() {
+    super();
+    const element = document.querySelector<RCarousel>(this.carousel);
+    if (!element) throw new Error("Thumbnails need an associated carousel");
+    this.carouselElement = element;
+  }
 
   get carousel() {
-    return this.getAttribute('carousel')!;
+    return this.getAttribute("carousel")!;
   }
 
   markCarouselScroll() {
@@ -18,14 +26,17 @@ export default class RThumbnails extends HTMLElement {
    * @param {number} index Thumbnail image index to set as active
    * @param {boolean} [forceScroll] Force scroll even if carousel might be scrolling
    */
-  setActiveThumbnail(index: number, forceScroll?: boolean) {
+  setActiveThumbnail(path: string, forceScroll?: boolean) {
     if (forceScroll || !this.carouselScrolling) {
-      const thumbnailElement = this.querySelector<HTMLImageElement>(`img:nth-of-type(${index + 1})`)!;
-      const activeThumbnail = this.querySelector('.active');
-      if (activeThumbnail) activeThumbnail.classList.remove('active');
-      thumbnailElement.classList.add('active');
+      const thumbnailElement = this.querySelector<HTMLImageElement>(
+        `img[data-path="${path}"]`,
+      )!;
+      const activeThumbnail = this.querySelector(".active");
+      if (activeThumbnail) activeThumbnail.classList.remove("active");
+      thumbnailElement.classList.add("active");
 
-      const thumbMiddle = thumbnailElement.offsetLeft + thumbnailElement.clientWidth / 2;
+      const thumbMiddle = thumbnailElement.offsetLeft +
+        thumbnailElement.clientWidth / 2;
       const thumbScrollPosition = thumbMiddle - this.clientWidth / 2;
       this.scrollTo(thumbScrollPosition, 0);
     }
@@ -34,18 +45,22 @@ export default class RThumbnails extends HTMLElement {
   }
 
   connectedCallback() {
-    const scrollEverything = (index: number) => {
-      const carousel = document.querySelector<RCarousel>(this.carousel)!;
-      carousel.scrollToImage(index);
+    const scrollEverything = (path: string) => {
+      this.carouselElement.scrollToImage(path);
       this.markCarouselScroll();
-      this.setActiveThumbnail(index, true);
+      this.setActiveThumbnail(path, true);
     };
 
-    this.addEventListener('click', (e) => {
-      const index = Number.parseInt((e.target as HTMLElement).dataset.index!);
-      scrollEverything(index);
+    this.carouselElement.addEventListener("image-changed", (e) => {
+      const { path } = e.detail;
+      this.setActiveThumbnail(path);
+    });
+
+    this.addEventListener("click", (e) => {
+      const path = (e.target as HTMLElement).dataset.path!;
+      scrollEverything(path);
     });
   }
 }
 
-window.customElements.define('r-thumbnails', RThumbnails);
+window.customElements.define("r-thumbnails", RThumbnails);

--- a/layouts/partials/product.html
+++ b/layouts/partials/product.html
@@ -273,8 +273,12 @@
 {{ $variants := slice }}
 {{ range .Params.variants }}
 {{ $variantImage := "not found" }}
+<!-- this is for the new shopify importer using the media bank -->
 {{ with $product.Resources.GetMatch (printf "*-%s/*" .productAndColor) }}
 {{ $variantImage = .Name }}
+<!-- this is for the original importer with shopify media -->
+{{ else }}
+{{ $variantImage = (index ($product.Resources.ByType "image") .imageIndex).Name }}
 {{ end }}
 {{ $variants = $variants | append (merge . (dict "imagePath" $variantImage)) }}
 {{ end }}

--- a/layouts/partials/product.html
+++ b/layouts/partials/product.html
@@ -16,10 +16,10 @@
         {{ $sizes := "(min-width: 768px) min(40vw, 536px), 100vw" }}
         {{ with index $imgs 0 }}
         <img srcset="{{partial "srcset" (dict "image" . "widths" "375,750")}}" src="{{(.Resize "375x").RelPermalink}}"
-          height="{{.Height}}" width="{{.Width}}" sizes="{{$sizes}}" data-index="{{.Name}}" />
+          height="{{.Height}}" width="{{.Width}}" sizes="{{$sizes}}" data-index="0" />
         {{ end }}
-        {{ range after 1 $imgs }}
-        {{partial "image" (dict "image" . "widths" "375,750" "sizes" $sizes "dataset" (dict "index" .Name))}}
+        {{ range $i, $img := after 1 $imgs }}
+        {{partial "image" (dict "image" . "widths" "375,750" "sizes" $sizes "dataset" (dict "index" $i))}}
         {{ end }}
       </div>
       {{ if gt (len $imgs) 1 }}
@@ -28,9 +28,9 @@
       {{ end }}
     </r-carousel>
     <r-thumbnails carousel="r-carousel">
-      {{ range $imgs }}
+      {{ range $i, $img := $imgs }}
       {{ $sizes := "(min-width: 768px) min(6vw, 82px), 15vw" }}
-      {{partial "image" (dict "image" . "widths" "100,200" "sizes" $sizes "dataset" (dict "index" .Name))}}
+      {{partial "image" (dict "image" . "widths" "100,200" "sizes" $sizes "dataset" (dict "index" $i))}}
       {{ end }}
     </r-thumbnails>
   </div>

--- a/layouts/partials/product.html
+++ b/layouts/partials/product.html
@@ -10,16 +10,16 @@
     {{ $variantSkus := apply .Params.variants "index" "." "sku" }}
     {{ $imgs = partial "get-variant-images" $variantSkus }}
     {{ end }}
-    <r-carousel thumbnails="r-thumbnails">
+    <r-carousel>
       <div>
         <!-- sizes: roughly 100vw up to 768px, 40vw but max 536px after that -->
         {{ $sizes := "(min-width: 768px) min(40vw, 536px), 100vw" }}
         {{ with index $imgs 0 }}
         <img srcset="{{partial "srcset" (dict "image" . "widths" "375,750")}}" src="{{(.Resize "375x").RelPermalink}}"
-          height="{{.Height}}" width="{{.Width}}" sizes="{{$sizes}}" data-index="0" />
+          height="{{.Height}}" width="{{.Width}}" sizes="{{$sizes}}" data-path="{{.Name}}" />
         {{ end }}
         {{ range $i, $img := after 1 $imgs }}
-        {{partial "image" (dict "image" . "widths" "375,750" "sizes" $sizes "dataset" (dict "index" $i))}}
+        {{partial "image" (dict "image" . "widths" "375,750" "sizes" $sizes "dataset" (dict "path" .Name))}}
         {{ end }}
       </div>
       {{ if gt (len $imgs) 1 }}
@@ -30,7 +30,7 @@
     <r-thumbnails carousel="r-carousel">
       {{ range $i, $img := $imgs }}
       {{ $sizes := "(min-width: 768px) min(6vw, 82px), 15vw" }}
-      {{partial "image" (dict "image" . "widths" "100,200" "sizes" $sizes "dataset" (dict "index" $i))}}
+      {{partial "image" (dict "image" . "widths" "100,200" "sizes" $sizes "dataset" (dict "path" .Name))}}
       {{ end }}
     </r-thumbnails>
   </div>
@@ -44,7 +44,7 @@
 
   <div>
 
-    <form action="/cart" method="POST" data-variant="{{$firstAvailableVariant.id}}" id="product-form">
+    <form action="/cart" method="POST" data-variant="{{$firstAvailableVariant.id}}" id="product-form" data-product-images="r-carousel">
       <!-- TODO: DEPRECATED -->
       <input type="hidden" name="product-id"
         value="{{printf "gid://shopify/Product/%s" .Params.yotpoId | base64Encode}}">
@@ -271,9 +271,20 @@
 {{ with $firstAvailableOptions }}
 {{ $selectedOptions = . }}
 {{ end }}
+<!-- create variants slice with added image path parameter -->
+{{ $variants := slice }}
+{{ range .Params.variants }}
+{{ $variantImage := 0 }}
+{{ if templates.Exists "partials/get-variant-image.html" }}
+{{ $variantImage = partial "get-variant-image" .sku }}
+{{ else }}
+{{ $variantImage = index ($product.Resources.ByType "image") .imageIndex }}
+{{ end }}
+{{ $variants = $variants | append (merge . (dict "imagePath" $variantImage.Name)) }}
+{{ end }}
 <script>
   handle = '{{.File.ContentBaseName}}';
-  variants = {{.Params.variants }};
+  variants = {{$variants}};
   yotpoId = '{{.Params.yotpoId}}';
   selectedOptions = {{ $selectedOptions }};
   priceTemplate = '{{T "Product price" (dict "price" "PRICE")}}';

--- a/layouts/partials/product.html
+++ b/layouts/partials/product.html
@@ -6,10 +6,6 @@
 <div class="product">
   <div>
     {{ $imgs := .Resources.ByType "image" }}
-    {{ if templates.Exists "partials/get-variant-images.html" }}
-    {{ $variantSkus := apply .Params.variants "index" "." "sku" }}
-    {{ $imgs = partial "get-variant-images" $variantSkus }}
-    {{ end }}
     <r-carousel>
       <div>
         <!-- sizes: roughly 100vw up to 768px, 40vw but max 536px after that -->
@@ -270,17 +266,17 @@
 {{ $selectedOptions := dict }}
 {{ with $firstAvailableOptions }}
 {{ $selectedOptions = . }}
+{{ else }}
+{{ $selectedOptions = (index $product.Params.variants 0).options }}
 {{ end }}
 <!-- create variants slice with added image path parameter -->
 {{ $variants := slice }}
 {{ range .Params.variants }}
-{{ $variantImage := 0 }}
-{{ if templates.Exists "partials/get-variant-image.html" }}
-{{ $variantImage = partial "get-variant-image" .sku }}
-{{ else }}
-{{ $variantImage = index ($product.Resources.ByType "image") .imageIndex }}
+{{ $variantImage := "not found" }}
+{{ with $product.Resources.GetMatch (printf "*-%s/*" .productAndColor) }}
+{{ $variantImage = .Name }}
 {{ end }}
-{{ $variants = $variants | append (merge . (dict "imagePath" $variantImage.Name)) }}
+{{ $variants = $variants | append (merge . (dict "imagePath" $variantImage)) }}
 {{ end }}
 <script>
   handle = '{{.File.ContentBaseName}}';

--- a/layouts/partials/product.html
+++ b/layouts/partials/product.html
@@ -6,6 +6,10 @@
 <div class="product">
   <div>
     {{ $imgs := .Resources.ByType "image" }}
+    {{ if templates.Exists "partials/get-variant-images.html" }}
+    {{ $variantSkus := apply .Params.variants "index" "." "sku" }}
+    {{ $imgs = partial "get-variant-images" $variantSkus }}
+    {{ end }}
     <r-carousel thumbnails="r-thumbnails">
       <div>
         <!-- sizes: roughly 100vw up to 768px, 40vw but max 536px after that -->


### PR DESCRIPTION
This PR adds a new importer script for importing products under `importers/shopify/cmd.ts`. This script currently imports products from Shopify without any images or other media, and downloads product images from the media bank.

Some notes on functionality:
- Product images are downloaded based on the variant SKUs in Shopify
- Existing images are not re-downloaded (matching based on filename only)
- The order of the images is based on the order of variants in Shopify

Downloading images and importing products is completely decoupled now, and product images can just be retrieved with `.Resources.ByType "image"` without any reliance on resource data in the product content frontmatter. The only coupling is that variants now have a `productAndColor` property to be able to find the variant image for scrolling the carousel when the color changes (or in reality when the primary variant image changes). For this, the product image carousel and thumbnails elements have been refactored to work with image paths instead of indexes. *There is, however, still some legacy code that understands the resource- and index-based data provided by the old importer still in use in production.*

The `r-carousel` now also does not need to know about a potential `r-thumbnails` - that state sync is now handled only in the thumbnails element. This is possible because the carousel now sends an `image-changed` event when the image changes.

A new `variant-changed` event is also now dispatched. This event should be useful for analytics.

The new importer does not rely on the legacy product mapping code. Some of the functionality (such as creating the product options array) was heavily copy-pasted from the legacy version, but at least it should be a bit more understandable and testable now.

Closes #176 