### PR TITLE
feat(gtm-pixel): Add GTM pixel option to Forestry

### DIFF
--- a/.forestry/front_matter/templates/pixels.yml
+++ b/.forestry/front_matter/templates/pixels.yml
@@ -172,5 +172,18 @@ fields:
   showOnly:
     field: luckyorange_enabled
     value: true
+- name: gtm_enabled
+  type: boolean
+  label: Google Tag Manager
+  description: Google Tag Manager delivers easily integrated tag management solutions.
+- type: text
+  name: gtm_property
+  label: GTM tracking id
+  showOnly:
+    field: gtm_enabled
+    value: true
+  config:
+    required: true
+  description: Google Tag Manager property / tracking id is the one starting with "GTM-".
 pages:
 - demo/data/pixels.yaml

--- a/demo/data/pixels.yaml
+++ b/demo/data/pixels.yaml
@@ -20,4 +20,6 @@ frosmo_site: reima_headless_dev
 frosmo_host: d22j8luu453d90.cloudfront.net
 luckyorange_enabled: true
 luckyorange_site: 1111
+gtm_enabled: true
+gtm_property: GTM-XXXXXXX
 aw_property: ''

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -51,6 +51,10 @@
     {{partial "css-critical" (slice "_default/baseof.noscript.css")}}
   </noscript>
 
+  {{ if hugo.IsProduction }}
+  {{ partial "pixels/gtm" .}}
+  {{ end }}
+
   <link rel="shortcut icon" href="/favicon-32x32.png" type="image/png">
   <link rel="preconnect" href="https://www.google-analytics.com">
   <meta name="description" content="{{with .Description}}{{. | truncate 300}}{{else}}{{T "SEO Description"}}{{end}}">
@@ -62,6 +66,10 @@
 </head>
 
 <body>
+  {{ if hugo.IsProduction }}
+  {{ partial "pixels/gtm-noscript" .}}
+  {{ end }}
+
   {{ $menus := partial "helpers/get-locale-data" "menus" }}
   {{ if $announcements.headerAnnouncementEnabled }}
   <aside class="announcement">

--- a/layouts/partials/pixels/gtm-noscript.html
+++ b/layouts/partials/pixels/gtm-noscript.html
@@ -2,7 +2,7 @@
 {{ if .gtm_enabled }}
 
 <!-- Google Tag Manager (noscript) -->
-<noscript>
+<noscript uses-cookies>
     <iframe src="https://www.googletagmanager.com/ns.html?id={{.gtm_property}}"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->

--- a/layouts/partials/pixels/gtm-noscript.html
+++ b/layouts/partials/pixels/gtm-noscript.html
@@ -1,0 +1,11 @@
+{{ with site.Data.pixels }}
+{{ if .gtm_enabled }}
+
+<!-- Google Tag Manager (noscript) -->
+<noscript>
+    <iframe src="https://www.googletagmanager.com/ns.html?id={{.gtm_property}}"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+
+{{ end }}
+{{ end }}

--- a/layouts/partials/pixels/gtm.html
+++ b/layouts/partials/pixels/gtm.html
@@ -1,0 +1,15 @@
+{{ with site.Data.pixels }}
+{{ if .gtm_enabled }}
+
+<!-- Google Tag Manager -->
+<script uses-cookies>
+  (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','{{.gtm_property}}');
+</script>
+<!-- End Google Tag Manager -->
+
+{{ end }}
+{{ end }}


### PR DESCRIPTION
# Why?

Google Tag Manager needs to be added as a pixel option to Forestry.

# How?

Add Google Tag Manager setup to partial templates and as an option to Forestry.

Closes: #185 