### PR TITLE
fix: Show benefits group only if it’s enabled

### DIFF
--- a/.forestry/front_matter/templates/announcements.yml
+++ b/.forestry/front_matter/templates/announcements.yml
@@ -157,6 +157,9 @@ fields:
 - name: benefits
   type: field_group
   config: {}
+  showOnly:
+    field: benefitsEnabled
+    value: true
   fields:
     - name: links
       type: field_group_list


### PR DESCRIPTION
# Why?

Benefits group at Forestry should be visible only if it's enabled.

# How?

Add "showOnly" check.
