### PR TITLE
fix(size-guide): Fix size guide content table

### DIFF
--- a/.forestry/front_matter/templates/product-page-settings.yml
+++ b/.forestry/front_matter/templates/product-page-settings.yml
@@ -96,7 +96,7 @@ fields:
       can use markdown here.
     config:
       required: true
-      wysiwyg: true
+      wysiwyg: false
       schema:
         format: markdown
   description: Configuration for product tags that should output size guide.


### PR DESCRIPTION
# Why?

Size guide Pop-up content is not rendered as a table.

# How?

Disable Pop-up content wysiwyg editor.

Closes: #207 
