### PR TITLE
fix(benefit-bar): Remove horizontal scrolling

### DIFF
--- a/layouts/partials/elements/benefits.css
+++ b/layouts/partials/elements/benefits.css
@@ -1,4 +1,8 @@
 .benefits {
+  border-top: 1px solid rgba(0,0,0,0.2);
+}
+
+.benefits .container {
   align-items: flex-start;
   box-sizing: border-box;
   display: flex;
@@ -7,17 +11,6 @@
   position: relative;
   margin: auto;
   max-width: var(--block-width);
-}
-
-.benefits::before {
-  background-color: rgba(0,0,0,0.2);
-  content: '';
-  height: 1px;
-  position: absolute;
-  transform: translateX(-50%);
-  left: 50%;
-  top: 0;
-  width: 100vw;
 }
 
 .benefits .benefit {
@@ -66,7 +59,7 @@
 }
 
 @media (min-width: 992px) {
-  .benefits {
+  .benefits .container {
     flex-direction: row;
   }
 

--- a/layouts/partials/elements/benefits.html
+++ b/layouts/partials/elements/benefits.html
@@ -2,27 +2,29 @@
 
 {{ with .benefits }}
 <section class="benefits">
-  {{ range .links }}
-  <a href="{{.url}}" class="benefit">
-    <div class="icon">
-      {{ if .icon }}
-      {{ $img := partial "helpers/get-image" .icon }}
-      <!-- check if this is png or jpeg and resize if it is -->
-      {{ if or (eq $img.MediaType.SubType "png") (eq $img.MediaType.SubType "jpeg")}}
-      {{ $onex := $img.Resize (printf "%dx" .width) }}
-      {{ $twox := $img.Resize (printf "%dx" (mul .width 2)) }}
-      <img srcset="{{$onex.RelPermalink}} 1x, {{$twox.RelPermalink}} 2x" src="{{$onex.RelPermalink}}" alt=""
-           width="{{$onex.Width}}" height="{{$onex.Height}}">
-      <!-- if some other type (like svg), just output directly -->
-      {{ else }}
-      <img src="{{$img.RelPermalink}}" alt="" width="{{.width}}"{{with .height}} height="{{.}}"{{end}}>
-      {{ end }}
-      {{ end }}
-    </div>
-    <h3 class="heading">{{.heading}}</h3>
-    <span class="cta">{{.text}}</span>
-  </a>
-  {{ end }}
+  <div class="container">
+    {{ range .links }}
+    <a href="{{.url}}" class="benefit">
+      <div class="icon">
+        {{ if .icon }}
+        {{ $img := partial "helpers/get-image" .icon }}
+        <!-- check if this is png or jpeg and resize if it is -->
+        {{ if or (eq $img.MediaType.SubType "png") (eq $img.MediaType.SubType "jpeg")}}
+        {{ $onex := $img.Resize (printf "%dx" .width) }}
+        {{ $twox := $img.Resize (printf "%dx" (mul .width 2)) }}
+        <img srcset="{{$onex.RelPermalink}} 1x, {{$twox.RelPermalink}} 2x" src="{{$onex.RelPermalink}}" alt=""
+             width="{{$onex.Width}}" height="{{$onex.Height}}">
+        <!-- if some other type (like svg), just output directly -->
+        {{ else }}
+        <img src="{{$img.RelPermalink}}" alt="" width="{{.width}}"{{with .height}} height="{{.}}"{{end}}>
+        {{ end }}
+        {{ end }}
+      </div>
+      <h3 class="heading">{{.heading}}</h3>
+      <span class="cta">{{.text}}</span>
+    </a>
+    {{ end }}
+  </div>
 </section>
 {{ else }}
 {{ warnf "Benefits not found for %s" site.Language }}


### PR DESCRIPTION
# Why?

Benefit bar creates horizontal scrollbar with some browsers, because incorrect top border CSS styling.

# How?

Add container element to simplify CSS and fix bug.

Closes #210 
