### PR TITLE
Fix/size guide close button

### DIFF
--- a/layouts/partials/product.html
+++ b/layouts/partials/product.html
@@ -133,7 +133,7 @@
         {{ with $size_guide.modal }}
         <div class="modal modal--full-width" id="size-guide-modal">
           <div>
-            <button class="icon" close>
+            <button class="icon" onclick="event.preventDefault()" close>
               <svg>
                 <use xlink:href="#icon-close"></use>
               </svg>

--- a/layouts/partials/product.ts
+++ b/layouts/partials/product.ts
@@ -27,7 +27,7 @@ type Options = {
 };
 
 const form = document.querySelector<HTMLFormElement>("form#product-form")!;
-const cartButton = form.querySelector("button")!;
+const cartButton = form.querySelector("button[type=submit]")!;
 const radioBoxes = form.querySelectorAll<HTMLInputElement>(
   "input[type=radio]",
 )!;


### PR DESCRIPTION
# Why?

Size guides close button will behave same way as Add cart button.

# How?

Add `event.preventDefault()` call when clicking close button and add more specific selector for Add cart button.
