### PR TITLE
fix(product-list): Center items on product list

### DIFF
--- a/layouts/partials/modules/products.css
+++ b/layouts/partials/modules/products.css
@@ -154,6 +154,7 @@
 
 @media (min-width: 992px) {
   .product-list ul {
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    grid-template-columns: repeat(auto-fit, 200px);
+    justify-content: center;
   }
 }


### PR DESCRIPTION
# Why?

If there is less than 6 items on product list on desktop breakpoint, items needs to be aligned to center.

# How?

Align items to center on desktop breakpoint.

Closes: #216 
