### PR TITLE
Fix/discounted price layout

### DIFF
--- a/layouts/partials/product-price.html
+++ b/layouts/partials/product-price.html
@@ -29,6 +29,6 @@
 <!-- we need to output the span because it might be needed on the product page -->
 <span class="price price--was">
   {{- with .compareAtPriceFormatted }}
-  {{T "Product price" (dict "price" .)}}
+  {{.}}
   {{- end }}
 </span>

--- a/layouts/partials/product.css
+++ b/layouts/partials/product.css
@@ -5,6 +5,7 @@
 }
 
 .product h1 {
+  margin-top: 0.625rem;
   margin-bottom: 0.625rem;
 }
 
@@ -64,6 +65,14 @@
   height: 30px;
   width: auto;
   display: inline;
+}
+
+.product-reviews .rating {
+  font-size: .875rem;
+}
+
+.product-reviews .review-count {
+  color: var(--color-text-muted);
 }
 
 .size-guide {
@@ -401,6 +410,10 @@ manually with CSS. The `[open]` attribute is still set on the
 
   .size-guide {
     margin: 24px 0 -6px 0;
+  }
+
+  .product h1 {
+    margin-top: 0;
   }
 }
 

--- a/layouts/partials/product.css
+++ b/layouts/partials/product.css
@@ -19,7 +19,7 @@
 }
 
 .product-prices .price {
-  font-size: 1.25rem;
+  font-size: 1rem;
   font-weight: 700;
 }
 

--- a/layouts/partials/product.html
+++ b/layouts/partials/product.html
@@ -57,8 +57,9 @@
         {{ end }}
         {{ with partial "helpers/get-reviews-bottomline" $product.Params.yotpoId }}
         <div>
-          <a href="#reviews" class="silent-link">
-            {{ range seq (math.Round .average) }}★{{ end }} {{ div (math.Round (mul .average 10)) 10 }} ({{.count}})
+          <a href="#reviews" class="product-reviews silent-link">
+            {{ range seq (math.Round .average) }}★{{ end }} <span class="rating">{{ div (math.Round (mul .average 10)) 10 }}
+            <span class="review-count">({{.count}})</span></span>
           </a>
         </div>
         {{ end }}


### PR DESCRIPTION
# Why?

At Reima JP site price is not fitting in mobile, if there is original and discounted price and reviews.

# How?

Update layout based on reimadesign.com. Set smaller font size for prices and ratings.
