### PR TITLE
feat(avant-link): Add Avant Link pixel configuration

### DIFF
--- a/.forestry/front_matter/templates/pixels.yml
+++ b/.forestry/front_matter/templates/pixels.yml
@@ -202,5 +202,23 @@ fields:
     required: true
   description: Google Tag Manager property / tracking id is the one starting with
     "GTM-".
+- name: avantlink_enabled
+  type: boolean
+  label: Avant Link
+- name: avantlink_id
+  type: text
+  config:
+    required: false
+  label: Avant Link account id
+  description: This is your Avant Link site ID, e.g. 111111.<br><br>
+    Step 2 - Install the order confirmation script<br>
+    From your Shopify admin, go to Settings > Checkout > Order Processing.<br>
+    Again, replace "1111111" with your site ID and paste the AvantLink order <br>
+    confirmation code in the "Additional Scripts" section.<br>
+    Code can be found <a href="https://support.avantlink.com/hc/en-us/articles/360022353991-Shopify-Integration-Guide"
+    title="" target="_blank">here</a>.
+  showOnly:
+    field: avantlink_enabled
+    value: true
 pages:
 - demo/data/pixels.yaml

--- a/demo/data/pixels.yaml
+++ b/demo/data/pixels.yaml
@@ -25,3 +25,5 @@ luckyorange_site: 1111
 gtm_enabled: true
 gtm_property: GTM-XXXXXXX
 aw_property: ''
+avantlink_enabled: true
+avantlink_id: 111111

--- a/layouts/partials/pixels/avantlink.html
+++ b/layouts/partials/pixels/avantlink.html
@@ -1,0 +1,15 @@
+{{ with site.Data.pixels }}
+{{ if .avantlink_enabled }}
+
+<!-- AvantLink -->
+<script uses-cookies>
+  (function() {
+    var avm = document.createElement('script'); avm.type = 'text/javascript'; avm.async = true;
+    avm.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'cdn.avmws.com/{{.avantlink_id}}/';
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(avm, s);
+  })();
+</script>
+<!-- End AvantLink -->
+
+{{ end }}
+{{ end }}

--- a/layouts/partials/pixels/index.html
+++ b/layouts/partials/pixels/index.html
@@ -20,6 +20,7 @@
 {{partial "pixels/taboola" .}}
 {{partial "pixels/frosmo" .}}
 {{partial "pixels/luckyorange" .}}
+{{partial "pixels/avantlink" .}}
 
 {{- else }}
 


### PR DESCRIPTION
 # Why?

Avant Link's affiliate marketing should be enabled for some countries.

# How?

Avant Link can be enabled in the same way as other pixels.  
