### PR TITLE
feat(theme-settings): Add theme settings section to Forestry

### DIFF
--- a/.forestry/front_matter/templates/theme-settings.yml
+++ b/.forestry/front_matter/templates/theme-settings.yml
@@ -1,0 +1,9 @@
+---
+label: Theme Settings
+hide_body: true
+fields:
+- name: show_discount_tags
+  type: boolean
+  label: Show Discount Tags
+  description: Hide/Show discount tags on product cards
+  default: true

--- a/.forestry/settings.yml
+++ b/.forestry/settings.yml
@@ -46,6 +46,10 @@ sections:
 - type: document
   path: i18n/en.json
   label: Translations
+- type: document
+  path: demo/data/themesettings.yaml
+  label: Settings
+  match: "**/*"
 upload_dir: demo/images
 public_path: ''
 front_matter_path: ''

--- a/demo/data/themesettings.yaml
+++ b/demo/data/themesettings.yaml
@@ -1,0 +1,2 @@
+---
+show_discount_tags: false

--- a/layouts/partials/modules/products.css
+++ b/layouts/partials/modules/products.css
@@ -12,7 +12,7 @@
   margin-right: .25rem;
 }
 
-.product-list .price--sale::before {
+.product-list .price--sale-tag::before {
   background-color: var(--color-text-emphasis-inverted);
   border-radius: 2px;
   color: var(--color-text);
@@ -185,7 +185,7 @@
     justify-content: center;
   }
 
-  .product-list .price--sale::before {
+  .product-list .price--sale-tag::before {
     font-size: 0.75rem;
     padding: 0.25rem 0.5rem;
   }

--- a/layouts/partials/product-price.html
+++ b/layouts/partials/product-price.html
@@ -18,11 +18,18 @@
 
 {{- define "partials/product-price-inner" }}
 {{- $discountPercentage := 0 }}
+{{- $showDiscountPercentageTag := false }}
 {{- if .compareAtPrice }}
   {{ $diff := (float (sub .compareAtPrice .price)) }}
   {{ $discountPercentage = math.Round (mul (div $diff .compareAtPrice) 100) }}
 {{end}}
-<span class="price price--actual {{if .compareAtPrice}}price--sale{{end}}" data-discount="{{ if $discountPercentage }} {{ (mul $discountPercentage -1)}}% {{end}}">
+
+{{ with site.Data.themesettings }}
+{{ if .show_discount_tags }}
+  {{ $showDiscountPercentageTag = .show_discount_tags }}
+{{ end }}
+{{ end }}
+<span class="price price--actual {{if .compareAtPrice}}price--sale{{end}} {{if and $showDiscountPercentageTag .compareAtPrice}}price--sale-tag{{end}}" data-discount="{{if $discountPercentage}} {{ (mul $discountPercentage -1)}}% {{end}}">
   {{- with .priceFormatted }}
   {{T "Product price" (dict "price" .) }}
   {{- else }}


### PR DESCRIPTION
# Why?

The new labeling style (based on reimadesign) should be enabled by default, but possible to use the old one by switching the setting.

# How?

Add theme settings section to Forestry

Closes: #236 