### PR TITLE
feat(sizebay): Add Sizebay pixel to Forestry

### DIFF
--- a/.forestry/front_matter/templates/pixels.yml
+++ b/.forestry/front_matter/templates/pixels.yml
@@ -219,5 +219,17 @@ fields:
   showOnly:
     field: avantlink_enabled
     value: true
+- name: sizebay_enabled
+  type: boolean
+  label: Sizebay
+- name: sizebay_id
+  type: text
+  config:
+    required: false
+  label: Sizebay account id
+  description: This is your Sizebay ID, e.g. 1234
+  showOnly:
+    field: avantlink_enabled
+    value: true
 pages:
 - demo/data/pixels.yaml

--- a/demo/data/pixels.yaml
+++ b/demo/data/pixels.yaml
@@ -27,3 +27,5 @@ gtm_property: GTM-XXXXXXX
 aw_property: ''
 avantlink_enabled: true
 avantlink_id: 111111
+sizebay_enabled: true
+sizebay_id: 1234

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -213,6 +213,7 @@
   </footer>
   {{partial "consent-banners" .}}
   {{partial "pixels/index" .}}
+  {{ block "scripts" . }}{{ end }}
   <!-- inline js -->
   {{partial "ts-inline" "_default/baseof.inline.ts"}}
   <script>

--- a/layouts/partials/pixels/sizebay.html
+++ b/layouts/partials/pixels/sizebay.html
@@ -1,0 +1,9 @@
+{{ with site.Data.pixels }}
+{{ if .sizebay_enabled }}
+
+<!-- Sizebay -->
+<script uses-cookies src="https://szb-tenants-production.s3.amazonaws.com/{{.sizebay_id}}/prescript.js" id="sizebay-vfr-v4"></script>
+<!-- End Sizebay -->
+
+{{ end }}
+{{ end }}

--- a/layouts/partials/product.html
+++ b/layouts/partials/product.html
@@ -135,6 +135,12 @@
       {{ end }}
       {{ end }}
 
+      {{ with site.Data.pixels }}
+      {{ if .sizebay_enabled }}
+      <div id="sizebay-container"></div>
+      {{ end }}
+      {{ end }}
+
       <!-- if this is the size guide section, show tag-based size guide -->
       {{ $size_guide := "" }}
       {{ range $product.Params.tags }}

--- a/layouts/products/single.html
+++ b/layouts/products/single.html
@@ -24,3 +24,7 @@
 {{partialCached "product" $ .File.ContentBaseName}}
 
 {{ end }}
+
+{{ define "scripts" }}
+{{ partial "partials/pixels/sizebay" .}}
+{{ end }}


### PR DESCRIPTION
# Why?

Sizebay needs to be added as a pixel option to Forestry.

# How?

Add Sizebay setup to partial templates and as an option to Forestry.
