### PR TITLE
feat(image-grid-options): Add links option and set zoom effect as optional

### DIFF
--- a/.forestry/front_matter/templates/image-grid.yml
+++ b/.forestry/front_matter/templates/image-grid.yml
@@ -27,6 +27,12 @@ fields:
         format: markdown
     label: Content
     description: Optional content to show in connection with the image card
+  - name: link
+    type: text
+    config:
+      required: false
+    label: Link
+    description: Link is only used if "Image Card as Link" is enabled.
   config:
     min: 1
     max: 
@@ -37,6 +43,25 @@ fields:
   label: Image Card Content as Pop-up
   description: Show (optional) content of the image cards in a pop-up instead of the
     default, which displays the content below the image
+- name: links
+  type: boolean
+  label: Image Card as Link
+  description: Add link if image card has link URL defined.
+- name: hover_effect
+  type: select
+  default: zoom
+  config:
+    required: false
+    options:
+    - zoom
+    - none
+    source:
+      type: simple
+      section:
+      file:
+      path:
+  label: Hover effect
+  description: Hover effect for Image card. Leave blank for the default "zoom" effect.
 - name: link
   type: boolean
   label: Button Below Grid

--- a/demo/content/modules/image-grid.md
+++ b/demo/content/modules/image-grid.md
@@ -28,6 +28,17 @@ modules:
 
       This is popup #3
 - template: image-grid
+  heading: Links
+  links: true
+  hover_effect: none
+  images:
+  - image: kids-square.jpg
+    link: /demo/collections/tops/products/juniors-sweater-winged/
+  - image: kids-square.jpg
+    link: /demo/collections/tops/products/juniors-sweater-winged/
+  - image: kids-square.jpg
+  - image: kids-square.jpg
+- template: image-grid
   heading: One column on mobile, three on desktop
   columnsmobile: '1'
   columnsdesktop: '3'

--- a/layouts/partials/modules/image-grid.css
+++ b/layouts/partials/modules/image-grid.css
@@ -51,16 +51,16 @@
   margin: 1rem 0;
 }
 
-.image-grid__zoom-container {
+.image-grid__container {
   overflow: hidden;
   display: block;
 }
 
-.image-grid__zoom-container img {
+.image-grid--effect-zoom .image-grid__container img {
   transition: transform 0.3s ease-out;
 }
 
-.image-grid__zoom-container img:hover {
+.image-grid--effect-zoom .image-grid__container img:hover {
   transform: scale(1.08);
 }
 

--- a/layouts/partials/modules/image-grid.html
+++ b/layouts/partials/modules/image-grid.html
@@ -9,6 +9,14 @@
 {{- if $popup }}
 {{- $class = printf "%s image-grid--modal" $class }}
 {{- end }}
+{{- $hover_effect := "zoom" }}
+{{- if .hover_effect }}
+{{ $hover_effect = .hover_effect }}
+{{- end }}
+{{- with $hover_effect }}
+{{- $class = printf "%s image-grid--effect-%v" $class . }}
+{{- end }}
+
 
 <!-- set up sizes attr -->
 {{ $cols_mobile := 2 }}
@@ -65,7 +73,7 @@
     {{ $modal_id := printf "%s%s" $grid_id $image_id }}
 
     <li>
-      <a class="image-grid__zoom-container" href="#{{$modal_id}}" onclick="document.body.style.overflow = 'hidden'">
+      <a class="image-grid__container" href="#{{$modal_id}}" onclick="document.body.style.overflow = 'hidden'">
         {{- partial "img" (dict "image" .image "widths" "300,600" "sizes" $sizes) }}
       </a>
       <aside class="image-grid__modal" id="{{$modal_id}}">
@@ -89,12 +97,18 @@
     </li>
     {{ else }}
     <li>
-      <div class="image-grid__zoom-container">
+      {{ if and $.links .link }}
+      <a href="{{ .link }}">
+      {{ end }}
+      <div class="image-grid__container">
         {{- partial "img" (dict "image" .image "widths" "300,600" "sizes" $sizes) }}
       </div>
       {{- with .content }}
       {{. | $.pageobj.RenderString}}
       {{- end }}
+      {{ if and $.links .link }}
+      </a>
+      {{ end }}
     </li>
     {{ end }}
     <!-- add show more if specified -->


### PR DESCRIPTION
# Why?

Image Grid needs option to show Image Cards as links. Zoom hover effect needs to be optional.

# How?

Add "Image Card as Link" option to Image Grid module and add "Hover effect" option where Zoom effect can be disabled. "Hover effect" option can be used for adding more effect types in future.

Closes: #229 
