### PR TITLE
fix(overlay-close): Fix JS error with overlay close

### DIFF
--- a/layouts/_default/baseof.ts
+++ b/layouts/_default/baseof.ts
@@ -33,9 +33,10 @@ const overlayClick = (e) => {
     e.target === e.currentTarget ||
     /** @type {HTMLElement} */ e.target.closest("[close]")
   ) {
-    /** @type {HTMLElement} */ e.currentTarget
-      .closest(".open")
-      .classList.remove("open");
+    const overlayElement: HTMLElement = e.currentTarget.closest(".open");
+    if (overlayElement) {
+      overlayElement.classList.remove("open");
+    }
     document.body.style.overflow = "";
   }
 };


### PR DESCRIPTION
# Why?

When clicking close button on mobile menu, it creates JS error.

# How?

Check that element exists before manipulating DOM.

Closes: #256 