### PR TITLE
fix(carousel): Fix carousel autoplay speed nil

### DIFF
--- a/.forestry/front_matter/templates/image-links-small.yml
+++ b/.forestry/front_matter/templates/image-links-small.yml
@@ -105,15 +105,12 @@ fields:
     value: true
   description: Enables Autoplay
 - name: carousel_autoplay_speed
-  type: number
+  type: text
+  config:
+    required: false
   label: Carousel Autoplay Speed
   description: Autoplay Speed in milliseconds
-  default: 7000
-  required: true
-  config:
-    min: 
-    max: 
-    step: 
+  default: '7000'
   showOnly:
     field: carousel_autoplay
     value: true

--- a/.forestry/front_matter/templates/image-links.yml
+++ b/.forestry/front_matter/templates/image-links.yml
@@ -165,15 +165,12 @@ fields:
     value: true
   description: Enables Autoplay
 - name: carousel_autoplay_speed
-  type: number
+  type: text
+  config:
+    required: false
   label: Carousel Autoplay Speed
   description: Autoplay Speed in milliseconds
-  default: 7000
-  required: true
-  config:
-    min: 
-    max: 
-    step: 
+  default: '7000'
   showOnly:
     field: carousel_autoplay
     value: true


### PR DESCRIPTION
# Why?

Reima US has some pages that are using old Forestry templates. This is causing error with carousel autoplay speed, if value is not defined.

# How?

Change carousel autoplay speed field type to text and set field as optional with 7000 as default value.
