### PR TITLE
fix(products-list): Fix prodcut list heading width

### DIFF
--- a/layouts/partials/modules/products.css
+++ b/layouts/partials/modules/products.css
@@ -35,7 +35,6 @@
 
 .product-list__heading h2 {
   flex: 1 1 auto;
-  width: max-content;
   margin-bottom: 0;
 }
 


### PR DESCRIPTION
# Why?

Product list heading will break layout if it can't fit to viewport.

# How?

Remove `width: max-content` CSS rule to allow content flow to multiple rows.
