### PR TITLE
feat(mailchimp-pixel): Add Mailchimp pixel option to Forestry

### DIFF
--- a/.forestry/front_matter/templates/pixels.yml
+++ b/.forestry/front_matter/templates/pixels.yml
@@ -231,5 +231,17 @@ fields:
   showOnly:
     field: sizebay_enabled
     value: true
+- name: mailchimp_enabled
+  type: boolean
+  label: Mailchimp
+- name: mailchimp_url
+  type: text
+  config:
+    required: false
+  label: Mailchimp script URL
+  description: Script URL for Mailchimp integration.
+  showOnly:
+    field: mailchimp_enabled
+    value: true
 pages:
 - demo/data/pixels.yaml

--- a/demo/data/pixels.yaml
+++ b/demo/data/pixels.yaml
@@ -29,3 +29,5 @@ avantlink_enabled: true
 avantlink_id: 111111
 sizebay_enabled: true
 sizebay_id: 1234
+mailchimp_enabled: true
+mailchimp_url: https://chimpstatic.com/mcjs-connected/js/users/db7b4ffa65e63166abb491a51/e57ede9a2a5b4c52b6f57709d.js

--- a/layouts/partials/pixels/index.html
+++ b/layouts/partials/pixels/index.html
@@ -21,6 +21,7 @@
 {{partial "pixels/frosmo" .}}
 {{partial "pixels/luckyorange" .}}
 {{partial "pixels/avantlink" .}}
+{{partial "pixels/mailchimp" .}}
 
 {{- else }}
 

--- a/layouts/partials/pixels/mailchimp.html
+++ b/layouts/partials/pixels/mailchimp.html
@@ -1,0 +1,11 @@
+{{ with site.Data.pixels }}
+{{ if .mailchimp_enabled }}
+
+<script uses-cookies id="mcjs">
+  !function(c,h,i,m,p) {
+    m=c.createElement(h),p=c.getElementsByTagName(h)[0],m.async=1,m.src=i,p.parentNode.insertBefore(m,p)
+  }(document,"script","{{.mailchimp_url}}");
+</script>
+
+{{ end }}
+{{ end }}


### PR DESCRIPTION
# Why?

Mailchimp needs to be added as a pixel option to Forestry.

# How?

Add Mailchimp setup to partial templates and as an option to Forestry.

Closes: #266 
