### PR TITLE
feat(enableRobotsTXT): Enable robots.txt

### DIFF
--- a/demo/config.yml
+++ b/demo/config.yml
@@ -5,6 +5,8 @@ disableKinds:
   - taxonomy
   - term
 
+enableRobotsTXT: true
+
 # uncomment these lines to test multilingual mode
 languages:
   en:

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,0 +1,10 @@
+# www.robotstxt.org/
+
+# Allow crawling of all content
+User-agent: *
+{{ range .Pages }}
+Disallow: {{ .RelPermalink }}
+{{ end }}
+
+# Sitemap
+sitemap: {{site.BaseURL}}sitemap.xml


### PR DESCRIPTION
# Why?

robots.txt is not enabled on reima-theme.

# How?

Enable robots.txt on reima-theme and add layout file for it.

Closes: #262 