### PR TITLE
fix(robots-txt): Remove noindex pages list

### DIFF
--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -2,9 +2,7 @@
 
 # Allow crawling of all content
 User-agent: *
-{{ range .Pages }}
-Disallow: {{ .RelPermalink }}
-{{ end }}
+Disallow:
 
 # Sitemap
 sitemap: {{site.BaseURL}}sitemap.xml


### PR DESCRIPTION
# Why?

Currently only sitemap is need to add to robots.txt

# How?

Remove noindex pages list.
