### PR TITLE
feat(robots-txt): Add list of noindex pages

### DIFF
--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -2,7 +2,9 @@
 
 # Allow crawling of all content
 User-agent: *
-Disallow:
+{{ range where .Pages ".Params.noindex" true}}
+Disallow: {{ .RelPermalink }}
+{{ end }}
 
 # Sitemap
 sitemap: {{site.BaseURL}}sitemap.xml


### PR DESCRIPTION
# Why?

Let's add list of noindex pages to robots.txt.

# How?

Loop pages that has noindex enabled and add disallow + URL.
