### PR TITLE
feat(gtag-conversion): Add Google Ads conversion ids

### DIFF
--- a/.forestry/front_matter/templates/pixels.yml
+++ b/.forestry/front_matter/templates/pixels.yml
@@ -61,6 +61,25 @@ fields:
   showOnly:
     field: ga_enabled
     value: true
+- name: aw_conversion_ids
+  type: boolean
+  label: Google Ads conversion ids
+- name: aw_add_to_cart_id
+  type: text
+  config:
+    required: false
+  label: Add to cart conversion id
+  showOnly:
+    field: aw_conversion_ids
+    value: true
+- name: aw_subscribe_newsletter_id
+  type: text
+  config:
+    required: false
+  label: Subscribe newsletter id
+  showOnly:
+    field: aw_conversion_ids
+    value: true
 - type: boolean
   label: Google Optimize
   name: googleoptimize_enabled

--- a/demo/data/pixels.yaml
+++ b/demo/data/pixels.yaml
@@ -25,6 +25,9 @@ luckyorange_site: 1111
 gtm_enabled: true
 gtm_property: GTM-XXXXXXX
 aw_property: ''
+aw_conversion_ids: true
+aw_add_to_cart_id: 'AW-XXXXXXX/XXXXXXX'
+aw_subscribe_newsletter_id: 'AW-XXXXXXX/XXXXXXX'
 avantlink_enabled: true
 avantlink_id: 111111
 sizebay_enabled: true

--- a/layouts/partials/pixels/ga.html
+++ b/layouts/partials/pixels/ga.html
@@ -20,6 +20,19 @@
 {{ end }}
 </script>
 
+{{ if .aw_conversion_ids }}
+{{ with .aw_subscribe_newsletter_id }}
+<!-- Event snippet for Subscribe conversion page -->
+<script uses-cookies>
+  document.addEventListener('subscribe', () => {
+    gtag('event', 'conversion', {
+      'send_to': '{{.}}'
+    });
+  });
+</script>
+{{ end }}
+{{ end }}
+
 <!-- product view enhanced ecommerce event -->
 {{ with partial "helpers/get-product" $ }}
 {{ $productId := $.File.ContentBaseName }}
@@ -60,6 +73,14 @@
         quantity: 1,
       }]
     });
+
+    {{ if .aw_conversion_ids }}
+    {{ with .aw_add_to_cart_id }}
+    gtag('event', 'conversion', {
+      'send_to': '{{.}}'
+    });
+    {{ end }}
+    {{ end }}
   });
 </script>
 {{ end }}


### PR DESCRIPTION
# Why?

We need to add Google Ads conversion events to "Add to cart" and "Subscribe to newsletter" events.

# How?

Add ID / label options to Forestry and implement scripts to ga.html template.
