### PR TITLE
fix(products-carousel): Fix carousel autoplay speed nil

### DIFF
--- a/.forestry/front_matter/templates/products.yml
+++ b/.forestry/front_matter/templates/products.yml
@@ -123,16 +123,12 @@ fields:
     value: true
   description: Enables Autoplay
 - name: carousel_autoplay_speed
-  type: number
+  type: text
+  config:
+    required: false
   label: Carousel Autoplay Speed
   description: Autoplay Speed in milliseconds
-  default: 7000
-  required: true
-  config:
-    min:
-    max:
-    step:
+  default: '7000'
   showOnly:
     field: carousel_autoplay
     value: true
-


### PR DESCRIPTION
# Why?

Reima US has some pages that are using TOML formatted templates. This is causing error with carousel autoplay speed, if value is not defined.

# How?

Change carousel autoplay speed field type to text and set field as optional with 7000 as default value.
