### PR TITLE
feat(product-videos): Add product videos

### DIFF
--- a/demo/products/products/juniors-sweater-vigur7/index.html
+++ b/demo/products/products/juniors-sweater-vigur7/index.html
@@ -149,6 +149,11 @@
       "originalSrc": "https://cdn.shopify.com/s/files/1/0313/0195/9817/products/536522-6320_3_b7ee1bf2-4590-4eef-bdb7-cd11877177dc.jpg?v=1594804369"
     }
   ],
+  "videos": [
+    {
+      "originalSrc": "https://cdn.shopify.com/videos/c/vp/b8125d5641734bb5b9ecf6a65e81aa75/b8125d5641734bb5b9ecf6a65e81aa75.HD-1080p-7.2Mbps.mp4?v=1594804369"
+    }
+  ],
   "hasOnlyDefaultVariant": true,
   "variants": [
     {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -166,5 +166,8 @@
   },
   "Account page title": {
     "other": "My Account"
+  },
+  "Video": {
+    "other": "Video"
   }
 }

--- a/layouts/partials/elements/r-thumbnails.ts
+++ b/layouts/partials/elements/r-thumbnails.ts
@@ -29,14 +29,14 @@ export default class RThumbnails extends HTMLElement {
   setActiveThumbnail(path: string, forceScroll?: boolean) {
     if (forceScroll || !this.carouselScrolling) {
       const thumbnailElement = this.querySelector<HTMLImageElement>(
-        `img[data-path="${path}"]`,
+        `img[data-path="${path}"]`
       )!;
       const activeThumbnail = this.querySelector(".active");
       if (activeThumbnail) activeThumbnail.classList.remove("active");
       thumbnailElement.classList.add("active");
 
-      const thumbMiddle = thumbnailElement.offsetLeft +
-        thumbnailElement.clientWidth / 2;
+      const thumbMiddle =
+        thumbnailElement.offsetLeft + thumbnailElement.clientWidth / 2;
       const thumbScrollPosition = thumbMiddle - this.clientWidth / 2;
       this.scrollTo(thumbScrollPosition, 0);
     }
@@ -58,7 +58,9 @@ export default class RThumbnails extends HTMLElement {
 
     this.addEventListener("click", (e) => {
       const path = (e.target as HTMLElement).dataset.path!;
-      scrollEverything(path);
+      if (path) {
+        scrollEverything(path);
+      }
     });
   }
 }

--- a/layouts/partials/product.css
+++ b/layouts/partials/product.css
@@ -35,6 +35,22 @@
   margin: 1rem 0;
 }
 
+.product .video-link {
+  border-top: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
+  display: block;
+  text-align: center;
+  text-decoration: none;
+  margin-bottom: 1rem;
+  padding: 1rem;
+}
+.product .video-link span {
+  display: block;
+  text-transform: uppercase;
+  font-size: .75rem;
+  font-weight: 700;
+}
+
 .product__add-to-cart {
   display: block;
   font-weight: 700;

--- a/layouts/partials/product.html
+++ b/layouts/partials/product.html
@@ -23,6 +23,23 @@
       <button next></button>
       {{ end }}
     </r-carousel>
+
+    {{ range $i, $video := .Params.videos }}
+    <a class="video-link" openid="video-{{$i}}">
+      <span>&#9654; {{T "Video"}}</span>
+    </a>
+    <div class="modal modal--video" id="video-{{$i}}">
+      <div>
+        <button class="icon" close>
+          <svg>
+            <use xlink:href="#icon-close"></use>
+          </svg>
+        </button>
+        <video autoplay muted controls src="{{.originalSrc}}"></video>
+      </div>
+    </div>
+    {{ end }}
+
     {{ if gt (len $imgs) 1 }}
     <r-thumbnails carousel="r-carousel">
       {{ range $i, $img := $imgs }}

--- a/layouts/partials/product.modal.css
+++ b/layouts/partials/product.modal.css
@@ -35,6 +35,23 @@
   padding: 1rem;
 }
 
+.modal.modal--video {
+  margin: 0;
+  padding: 0;
+}
+.modal.modal--video > div {
+  background: transparent;
+  padding: 2rem;
+}
+.modal.modal--video video {
+  width: 100%;
+  height: auto;
+  max-height: 80vh;
+}
+.modal.modal--video button[close] {
+  right: 0.5rem;
+  top: 0.5rem;
+}
 
 .modal button[close] {
   position: absolute;


### PR DESCRIPTION
Add videos to product page
- Videos added to Shopify are displayed as "thumbnails" below the product image - reference https://reima.com/fi/hidden/Lasten-talvihaalari-Stavanger/p/520265-3530
- The video should open in player and start playing when the thumbnail is clicked
- An event is sent to Google Analytics when the video is clicked

Closes: #105