### PR TITLE
feat(menu): Add additional content section to menu

### DIFF
--- a/.forestry/front_matter/templates/menus.yml
+++ b/.forestry/front_matter/templates/menus.yml
@@ -56,6 +56,20 @@ fields:
     label: Highlight Menu Entry
   config:
     labelField: name
+- name: additional_content
+  type: field_group_list
+  label: Main Menu Additional Items
+  description: Additional items are only visible on Mobile breakpoint
+  fields:
+  - name: additional_menu_entry
+    type: include
+    config: {}
+    template: image-links-small
+    label: Additional Menu Entry
+  config:
+    min:
+    max:
+    labelField: name
 - name: footer
   type: field_group_list
   fields:

--- a/demo/data/menus.json
+++ b/demo/data/menus.json
@@ -162,6 +162,47 @@
       "url": "/modules/hero"
     }
   ],
+  "additional_content": [
+    {
+      "images": [
+        {
+          "title": "Link 1",
+          "link": "/collections/tops",
+          "image": "/kids-square.jpg"
+        },
+        {
+          "title": "Link 2",
+          "link": "/collections/tops",
+          "image": "/kids-square.jpg"
+        }
+      ],
+      "heading": "",
+      "columnstablet": "",
+      "columnsdesktop": "",
+      "carousel_enabled": false,
+      "carousel_dots": false,
+      "carousel_arrows": false,
+      "carousel_autoplay": false,
+      "carousel_autoplay_speed": ""
+    },
+    {
+      "images": [
+        {
+          "title": "Link 3",
+          "link": "/collections/tops",
+          "image": "/3-sneak-peek.jpg"
+        }
+      ],
+      "heading": "",
+      "columnstablet": "",
+      "columnsdesktop": "",
+      "carousel_enabled": false,
+      "carousel_dots": false,
+      "carousel_arrows": false,
+      "carousel_autoplay": false,
+      "carousel_autoplay_speed": ""
+    }
+  ],
   "footer": [
     {
       "name": "Shopping Info",

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -32,6 +32,7 @@
   {{ $.Scratch.Add "css-base" "partials/elements/r-cart.css" }}
   {{ $.Scratch.Add "css-base" "partials/consent-banners.css" }}
   {{ $.Scratch.Add "css-base" "partials/carousel.css" }}
+  {{ $.Scratch.Add "css-base" "partials/menu.css" }}
   <!-- if newsletter enabled, add that css and add ts here as well -->
   {{ if $announcements.newsletterEnabled }}
   {{ $.Scratch.Add "css-base" "partials/elements/r-newsletter.css" }}
@@ -117,6 +118,9 @@
             <div class="menu__scroller">
               {{ partialCached "menu" (dict "menu" $menus.main "root" $) "main" }}
               {{ partialCached "menu" (dict "menu" $menus.highlight "root" $) "highlight" }}
+              {{ range $menus.additional_content }}
+                {{ partial "modules/image-links-small" . }}
+              {{ end }}
             </div>
           </div>
         </div>

--- a/layouts/partials/menu.css
+++ b/layouts/partials/menu.css
@@ -1,0 +1,33 @@
+.menu .module-image-links-small > div {
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+  padding: 0 10px 10px 10px;
+}
+
+.menu .module-image-links-small .title {
+  display: none;
+}
+
+.menu .carousel {
+  margin-bottom: 20px
+}
+.menu .carousel ol {
+  bottom: -24px
+}
+
+#menu .carousel .carousel__item {
+  border: 0 none;
+  padding: 0;
+}
+
+#menu .carousel ol li {
+  border: 0 none;
+  padding: 0 5px;
+}
+
+@media (min-width: 1024px) {
+  .menu .module-image-links-small {
+    display: none;
+  }
+}

--- a/layouts/partials/modules/image-links-small.html
+++ b/layouts/partials/modules/image-links-small.html
@@ -10,9 +10,11 @@
 {{ end }}
 
 <div class="{{$class}}">
+  {{ if .heading }}
   <h2>
     {{.heading}}
   </h2>
+  {{ end }}
   {{ if .carousel_enabled }}
   {{ $carousel_autoplay_speed := 7000 }}
   {{- if .carousel_autoplay_speed }}
@@ -29,7 +31,7 @@
        -->
         {{ $sizes := "158px" }}
         {{ partial "img" (dict "image" .image "widths" "158,316" "sizes" $sizes) }}
-        {{ .title }}
+      <span class="title">{{ .title }}</span>
       </a>
     </div>
     {{ end }}


### PR DESCRIPTION
# Why?

We need to be able to add image links as additional content to mobile menu.

# How?

Add additional content section to Forestry menus and update menu template.

Closes: #284 