### PR TITLE
fix(translations): Add video translation

### DIFF
--- a/.forestry/front_matter/templates/translations.yml
+++ b/.forestry/front_matter/templates/translations.yml
@@ -429,3 +429,13 @@ fields:
     label: other
     default: Most popular
     description: E.g. "Most popular"
+- type: field_group
+  name: Video
+  label: Video
+  description: Text for the Video button.
+  fields:
+  - type: text
+    name: other
+    label: other
+    default: Video
+    description: E.g. "Video"


### PR DESCRIPTION
# Why?

Video translation is missing from translations

# How?

Add it to Forestry front matter.
