### PR TITLE
fix(product-features): Add wrapper elements to features

### DIFF
--- a/layouts/partials/product.css
+++ b/layouts/partials/product.css
@@ -464,16 +464,16 @@ manually with CSS. The `[open]` attribute is still set on the
   color: var(--color-link);
 }
 
-.features > svg {
+.features .feature > svg {
   width: 50px;
 }
 
-.features > svg + svg {
+.features .feature > svg + svg {
   margin-left: 0.25rem;
 }
 
-.features > svg,
-.features > svg path {
+.features .feature > svg,
+.features .feature > svg path {
   fill: var(--color-text-muted) !important;
 }
 

--- a/layouts/partials/product.html
+++ b/layouts/partials/product.html
@@ -273,6 +273,7 @@
       {{ if eq $field "info" }}
       <div class="features">
         {{ range $product.Params.tags }}
+
         {{ $tagData := split . ":" }}
         {{ $tag := index $tagData 0 }}
         {{ $value := index $tagData 1 }}
@@ -280,45 +281,48 @@
         {{ range where $settings.features "tag" $tag }}
         {{ $modalid := .title }}
         <!-- feature heading with modal link if modal exists -->
-        <div>
-          <h3 class="features__heading">
-            {{ if .modal }}
-            <a href="#" openid="{{$modalid}}" class="silent-link">
+        <div class="feature">
+          <div class="feature__title">
+            <h3 class="features__heading">
+              {{ if .modal }}
+              <a href="#" openid="{{$modalid}}" class="silent-link">
+                {{.title}}
+              </a>
+              {{ else }}
               {{.title}}
-            </a>
-            {{ else }}
-            {{.title}}
-            {{ end }}
-          </h3>
-        </div>
-        <!-- modal if specified -->
-        {{ with .modal }}
-        <div class="modal" id="{{$modalid}}">
-          <div>
-            <button class="icon" close>
-              <svg>
-                <use xlink:href="#icon-close"></use>
-              </svg>
-            </button>
-            {{. | $product.Page.RenderString}}
+              {{ end }}
+            </h3>
           </div>
+          <!-- modal if specified -->
+          {{ with .modal }}
+          <div class="modal" id="{{$modalid}}">
+            <div>
+              <button class="icon" close>
+                <svg>
+                  <use xlink:href="#icon-close"></use>
+                </svg>
+              </button>
+              {{. | $product.Page.RenderString}}
+            </div>
+          </div>
+          {{ end }}
+
+          <!-- icons -->
+          {{ range .values }}
+          {{ $iconValue := .value }}
+          {{ with partial "helpers/get-image" .icon }}
+          {{ $svg := .Content }}
+          {{ if eq $iconValue $value }}
+          {{ $svg = replace $svg "<svg" "<svg class=\"active\"" }}
+          {{ end }}
+          {{$svg | safeHTML}}
+          {{ end }}
+          {{ end }}
+          <!-- tag description e.g. "Waterproof level 8000 mm" -->
+          <p>
+            {{ replace .description "VALUE" $value }}
+          </p>
         </div>
-        {{ end }}
-        <!-- icons -->
-        {{ range .values }}
-        {{ $iconValue := .value }}
-        {{ with partial "helpers/get-image" .icon }}
-        {{ $svg := .Content }}
-        {{ if eq $iconValue $value }}
-        {{ $svg = replace $svg "<svg" "<svg class=\"active\"" }}
-        {{ end }}
-        {{$svg | safeHTML}}
-        {{ end }}
-        {{ end }}
-        <!-- tag description e.g. "Waterproof level 8000 mm" -->
-        <p>
-          {{ replace .description "VALUE" $value }}
-        </p>
         {{ end }}
         {{ end }}
       </div>


### PR DESCRIPTION
# Why?

Product features would need to be displayed more compact style

# How?

Add wrapper elements to product features that it would be possible to so have i.e. 50 / 50 layout.

