### PR TITLE
feat(product-features): Add 2 column layout

### DIFF
--- a/layouts/partials/product.css
+++ b/layouts/partials/product.css
@@ -485,3 +485,17 @@ manually with CSS. The `[open]` attribute is still set on the
 .features p {
   margin-top: 0.25rem;
 }
+
+.features--col-2 {
+  display: flex;
+  flex-direction: row;
+}
+.features--col-2 p {
+  font-size: .875rem;
+}
+.features--col-2 .feature {
+  width: 50%;
+}
+.features--col-2 .feature > svg {
+  width: 32px;
+}


### PR DESCRIPTION
# Why?

Product features would need to be displayed more compact style.

# How?

Add CSS class for 50 / 50 layout.

