### PR TITLE
fix(product-features): Add flex wrap

### DIFF
--- a/layouts/partials/product.css
+++ b/layouts/partials/product.css
@@ -489,6 +489,7 @@ manually with CSS. The `[open]` attribute is still set on the
 .features--col-2 {
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
 }
 .features--col-2 p {
   font-size: .875rem;


### PR DESCRIPTION
# Why?

Product features would need to be displayed more compact style.

# How?

Add flex wrap to fix 50 / 50 layout.

