### PR TITLE
fix(img-alt-attributes): Add missing img alt attributes

### DIFF
--- a/layouts/_default/cart.html
+++ b/layouts/_default/cart.html
@@ -12,7 +12,7 @@
   <ul items>
     {{- range .Params.items -}}
     <li>
-      <img src="{{.img}}">
+      <img src="{{.img}}" alt="">
       <div>
         <h2>{{.title}}</h2>
         <h3>{{.variant}}</h3>

--- a/layouts/partials/carousel.html
+++ b/layouts/partials/carousel.html
@@ -21,11 +21,11 @@
                 {{- end }}
                 <img
                         src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 {{.Width}} {{.Height}}'%3E%3C/svg%3E"
-                        class="lazyload" loading="lazy" data-srcset="{{partial "srcset" $params}}"
+                        class="lazyload" loading="lazy" alt="" data-srcset="{{partial "srcset" $params}}"
                 data-src="{{$default.RelPermalink}}" sizes="(min-width: 768px) {{$sizes}}, 100vw" />
             </picture>
             <noscript>
-                <img loading="lazy" srcset="{{partial "srcset" $params}}" src="{{$default.RelPermalink}}" height="{{.Height}}"
+                <img loading="lazy" alt="" srcset="{{partial "srcset" $params}}" src="{{$default.RelPermalink}}" height="{{.Height}}"
                 width="{{.Width}}" />
             </noscript>
             {{ end }}

--- a/layouts/partials/modules/hero.html
+++ b/layouts/partials/modules/hero.html
@@ -83,11 +83,11 @@
     {{- end }}
     <img class="lazyload" {{if $lazyload}} loading="lazy"
       srcset="data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20{{$default.Width}}%20{{$default.Height}}'></svg>"
-      {{end}} src="{{$default.RelPermalink}}" width="{{.Width}}" height="{{.Height}}" />
+      {{end}} src="{{$default.RelPermalink}}" width="{{.Width}}" height="{{.Height}}" alt="" />
   </picture>
   <noscript>
     <img {{if $lazyload}}loading="lazy" {{end}} srcset="{{partial "srcset" $params}}" src="{{$default.RelPermalink}}"
-      height="{{.Height}}" width="{{.Width}}" />
+      height="{{.Height}}" width="{{.Width}}" alt="" />
   </noscript>
   {{- end }}
   {{- else }}

--- a/layouts/partials/modules/image-links.html
+++ b/layouts/partials/modules/image-links.html
@@ -54,12 +54,12 @@
         {{- end }}
         <img
           src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 {{.Width}} {{.Height}}'%3E%3C/svg%3E"
-          class="lazyload" loading="lazy" data-srcset="{{partial "srcset" $params}}"
+          class="lazyload" loading="lazy" alt="" data-srcset="{{partial "srcset" $params}}"
           data-src="{{$default.RelPermalink}}" sizes="(min-width: 768px) {{$sizes}}, 100vw" />
       </picture>
       <noscript>
         <img loading="lazy" srcset="{{partial "srcset" $params}}" src="{{$default.RelPermalink}}" height="{{.Height}}"
-          width="{{.Width}}" />
+          width="{{.Width}}" alt="" />
       </noscript>
       {{ end }}
       {{- else }}

--- a/layouts/partials/modules/milestones.html
+++ b/layouts/partials/modules/milestones.html
@@ -13,7 +13,7 @@
                             {{(.Fill "100x100").RelPermalink}} 100w,
                             {{(.Fill "200x200").RelPermalink}} 200w"
                             sizes="(min-width: 768px) 100px, 70px"
-                            data-src="{{(.Fill "100x100").RelPermalink}}" />
+                            data-src="{{(.Fill "100x100").RelPermalink}}" alt="" />
                         {{ end }}
                     </div>
                 </div>

--- a/layouts/partials/product.html
+++ b/layouts/partials/product.html
@@ -12,7 +12,7 @@
         {{ $sizes := "(min-width: 768px) min(40vw, 536px), 100vw" }}
         {{ with index $imgs 0 }}
         <img srcset="{{partial "srcset" (dict "image" . "widths" "375,750")}}" src="{{(.Resize "375x").RelPermalink}}"
-          height="{{.Height}}" width="{{.Width}}" sizes="{{$sizes}}" data-path="{{.Name}}" />
+          height="{{.Height}}" width="{{.Width}}" sizes="{{$sizes}}" data-path="{{.Name}}" alt="" />
         {{ end }}
         {{ range $i, $img := after 1 $imgs }}
         {{partial "image" (dict "image" . "widths" "375,750" "sizes" $sizes "dataset" (dict "path" .Name))}}


### PR DESCRIPTION
# Why?

All `img` tags should have alt attribute.

# How?

Add missing `img` alt attributes.

Closes: #300 
