### PR TITLE
Fix/benefits payments block

### DIFF
--- a/layouts/partials/product-payments-benefits-links.html
+++ b/layouts/partials/product-payments-benefits-links.html
@@ -16,7 +16,7 @@ Expects the product page as context.
 <p><a class="link--no-color" href="#" openid="{{$id}}">{{.title}}</a></p>
 <div class="modal" id="{{$id}}">
   <div>
-    <button class="icon" close>
+    <button class="icon" onclick="event.preventDefault()" close>
       <svg>
         <use xlink:href="#icon-close"></use>
       </svg>

--- a/layouts/partials/product.css
+++ b/layouts/partials/product.css
@@ -83,6 +83,7 @@
 .product__payment-logos {
   display: flex;
   margin: 0 1rem;
+  flex-wrap: wrap;
 }
 
 .product__benefits {
@@ -101,7 +102,7 @@
   height: 24px;
   width: auto;
   display: block;
-  margin-right: 10px;
+  margin: 0 10px 10px 0;
 }
 
 .product-reviews .rating {


### PR DESCRIPTION
# Why?

Fix payments & benefits block UI bug.

# How?

Add `flex-wrap: wrap` and `event.preventDefault()` on modal close.
