### PR TITLE
feat(meta-title-forestry): add meta title to forestry

### DIFF
--- a/.forestry/front_matter/templates/seo-properties.yml
+++ b/.forestry/front_matter/templates/seo-properties.yml
@@ -2,18 +2,14 @@
 label: SEO Properties
 hide_body: true
 fields:
-- name: title
-  type: textarea
-  default: ''
+- name: seotitle
+  type: text
   config:
     required: false
-    wysiwyg: false
-    schema:
-      format: markdown
-    max: 300
-  label: Title
+    max: 60
+  label: Seo Title
   description: Title for SEO purposes. If left empty, the SEO title for
-    the page will be the default title set on the site level.
+    the page will be the default title.
 - name: description
   type: textarea
   default: ''

--- a/.forestry/front_matter/templates/seo-properties.yml
+++ b/.forestry/front_matter/templates/seo-properties.yml
@@ -2,6 +2,18 @@
 label: SEO Properties
 hide_body: true
 fields:
+- name: title
+  type: textarea
+  default: ''
+  config:
+    required: false
+    wysiwyg: false
+    schema:
+      format: markdown
+    max: 300
+  label: Title
+  description: Title for SEO purposes. If left empty, the SEO title for
+    the page will be the default title set on the site level.
 - name: description
   type: textarea
   default: ''

--- a/demo/config.yml
+++ b/demo/config.yml
@@ -1,4 +1,5 @@
 baseURL: https://reima-demo.netlify.app/
+title: Reima Demo
 buildDrafts: true
 disableFastRender: true
 disableKinds:

--- a/importers/import-collections/content.ts
+++ b/importers/import-collections/content.ts
@@ -12,21 +12,29 @@ export type Content<t, T, A = {}> = {
   content: T;
 } & A;
 
-export type CollectionContent = Content<"collection", {
-  layout: "collection";
-  handle: CollectionHandle;
-  title: string;
-  seotitle: string;
-  seodescription: string;
-  filters: boolean;
-  main: Array<ContentModule>;
-}>;
+export type CollectionContent = Content<
+  "collection",
+  {
+    layout: "collection";
+    handle: CollectionHandle;
+    title: string;
+    seotitle: string;
+    seodescription: string;
+    filters: boolean;
+    main: Array<ContentModule>;
+  }
+>;
 
-export type CollectionProductContent = Content<"product", {
-  type: "products";
-  noindex: true;
-  weight: number;
-}, { collection: CollectionHandle }>;
+export type CollectionProductContent = Content<
+  "product",
+  {
+    type: "products";
+    noindex: true;
+    weight: number;
+    title: string;
+  },
+  { collection: CollectionHandle }
+>;
 
 export type CollectionTypeContent =
   | CollectionContent
@@ -45,7 +53,7 @@ type ContentModuleProductList = ContentModuleBase<
 type ContentModule = ContentModuleProductList;
 
 export const toCollectionContent = (
-  collection: Collection,
+  collection: Collection
 ): CollectionContent => ({
   path: `${collection.handle}/_index.md`,
   type: "collection",
@@ -56,25 +64,27 @@ export const toCollectionContent = (
     seotitle: collection.seoTitle,
     seodescription: collection.seoDescription,
     filters: true,
-    main: [{
-      template: "products",
-      collection: collection.handle,
-    }],
+    main: [
+      {
+        template: "products",
+        collection: collection.handle,
+      },
+    ],
   },
 });
 
 export const toCollectionProductContent = (
   collectionProduct: CollectionProduct,
-  counter: number,
+  counter: number
 ): CollectionProductContent => ({
-  path:
-    `${collectionProduct.collection}/products/${collectionProduct.handle}.md`,
+  path: `${collectionProduct.collection}/products/${collectionProduct.handle}.md`,
   type: "product",
   collection: collectionProduct.collection,
   content: {
     noindex: true,
     type: "products",
     weight: counter,
+    title: collectionProduct.title,
   },
 });
 
@@ -82,24 +92,21 @@ export const toCollectionProductContent = (
  * This interface is needed to explicitly set the right overload in map calls etc.
  */
 export interface ToContentWithType<T> {
-  (
-    obj: T,
-    counter: number | undefined,
-  ): CollectionTypeContent;
+  (obj: T, counter: number | undefined): CollectionTypeContent;
 }
 
 export function toContent(
   obj: CollectionType,
-  counter: number | undefined,
+  counter: number | undefined
 ): CollectionTypeContent;
 export function toContent(
   obj: FileContent,
-  counter: number | undefined,
+  counter: number | undefined
 ): CollectionTypeContent;
 
 export function toContent(
   obj: CollectionType | FileContent,
-  counter: number | undefined = 0,
+  counter: number | undefined = 0
 ): CollectionTypeContent {
   if ("type" in obj) {
     switch (obj.type) {

--- a/importers/import-collections/domain.ts
+++ b/importers/import-collections/domain.ts
@@ -14,6 +14,7 @@ import {
 
 export type CollectionHandle = string;
 export type ProductHandle = string;
+export type ProductTitle = string;
 
 export type Collection = {
   type: "collection";
@@ -26,13 +27,14 @@ export type Collection = {
 export type CollectionProduct = {
   type: "product";
   handle: ProductHandle;
+  title: ProductTitle;
   collection: CollectionHandle;
 };
 
 export type CollectionType = Collection | CollectionProduct;
 
 export const mapCollection = (
-  bulkCollection: CollectionShopify,
+  bulkCollection: CollectionShopify
 ): Collection => ({
   type: "collection",
   handle: bulkCollection.handle,
@@ -45,7 +47,7 @@ export const mapCollection = (
 
 export const collectionHandleReducer = (
   collectionHandles: { [id: string]: string },
-  collection: CollectionShopify,
+  collection: CollectionShopify
 ) => {
   return {
     ...collectionHandles,
@@ -56,35 +58,34 @@ export const collectionHandleReducer = (
 /**
  * @param collectionHandles Map (object) of collection ids to handles
  */
-export const mapCollectionProduct = (
-  collectionHandles: { [id: string]: string },
-) =>
-  (
-    bulkCollectionProduct: CollectionProductShopify,
-  ): CollectionProduct | undefined => {
-    const collection = collectionHandles[bulkCollectionProduct.__parentId];
-    // if collection not found, it most means that the collection is not published
-    if (!collection) return;
-    return ({
-      type: "product",
-      handle: bulkCollectionProduct.handle,
-      collection,
-    });
+export const mapCollectionProduct = (collectionHandles: {
+  [id: string]: string;
+}) => (
+  bulkCollectionProduct: CollectionProductShopify
+): CollectionProduct | undefined => {
+  const collection = collectionHandles[bulkCollectionProduct.__parentId];
+  // if collection not found, it most means that the collection is not published
+  if (!collection) return;
+  return {
+    type: "product",
+    handle: bulkCollectionProduct.handle,
+    title: bulkCollectionProduct.title,
+    collection,
   };
+};
 
 export const objectToDomain = (
   mapCollectionProduct: (
-    bulkCollectionProduct: CollectionProductShopify,
-  ) => CollectionProduct | undefined,
-) =>
-  (obj: Node): CollectionType | undefined => {
-    switch (getNodeType(obj.id)) {
-      case NodeType.Collection:
-        return mapCollection(obj as CollectionShopify);
-      case NodeType.Product:
-        return mapCollectionProduct(obj as CollectionProductShopify);
-    }
-  };
+    bulkCollectionProduct: CollectionProductShopify
+  ) => CollectionProduct | undefined
+) => (obj: Node): CollectionType | undefined => {
+  switch (getNodeType(obj.id)) {
+    case NodeType.Collection:
+      return mapCollection(obj as CollectionShopify);
+    case NodeType.Product:
+      return mapCollectionProduct(obj as CollectionProductShopify);
+  }
+};
 
 // jsonl to domain object
 
@@ -101,6 +102,6 @@ export const jsonlToObjects = (jsonl: Jsonl): CollectionType[] => {
   const mapProduct = mapCollectionProduct(collectionHandles);
   const domainObjects = parsed
     .map(objectToDomain(mapProduct))
-    .filter(Boolean as unknown as (input: any) => input is CollectionType);
+    .filter((Boolean as unknown) as (input: any) => input is CollectionType);
   return domainObjects;
 };

--- a/importers/import-collections/queries.ts
+++ b/importers/import-collections/queries.ts
@@ -76,6 +76,7 @@ export const collectionBulkQuery: BulkQuery = `
             node {
               id
               handle
+              title
               publishedOnCurrentPublication
               seo {
                 title
@@ -104,12 +105,16 @@ export type CollectionShopify = {
 export type CollectionProductShopify = {
   id: string;
   handle: string;
+  title: string;
   publishedOnCurrentPublication: boolean;
   __parentId: ID;
 };
 
-export type CollectionTypeShopify = CollectionShopify | CollectionProductShopify;
+export type CollectionTypeShopify =
+  | CollectionShopify
+  | CollectionProductShopify;
 
 export type Jsonl = string;
 
-export const toCollectionTypeShopify = (json: string) => JSON.parse(json) as CollectionTypeShopify;
+export const toCollectionTypeShopify = (json: string) =>
+  JSON.parse(json) as CollectionTypeShopify;

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -10,8 +10,16 @@
   {{ end }}
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>{{if .Params.seotitle}}{{.Params.seotitle}}{{else if .Title}}{{.Title}}{{with site.Title}} |
-    {{.}}{{end}}{{else}}{{site.Title}}{{end}}</title>
+  {{ $pageTitle := site.Title }}
+  {{ if .Params.seotitle }}
+  {{ $pageTitle = .Params.seotitle }}
+  {{ else if .Title }}
+  {{ $pageTitle = .Title }}
+  {{ else if eq .Params.type "products" }}
+  {{ $product := partial "helpers/get-product" . }}
+  {{ $pageTitle = printf "%s | %v" $product.Title site.Title }}
+  {{ end }}
+  <title>{{ $pageTitle }}</title>
   {{ partial "baseof/head-top.html" . }}
 
   <!-- create list of and for scripts -->

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -13,11 +13,11 @@
   {{ $pageTitle := site.Title }}
   {{ if .Params.seotitle }}
   {{ $pageTitle = .Params.seotitle }}
-  {{ else if in .RelPermalink "products" }}
-  {{ $product := partial "helpers/get-product" . }}
-  {{ $pageTitle = printf "%s | %v" $product.Title site.Title }}
   {{ else if .Title }}
   {{ $pageTitle = printf "%v | %v" .Title site.Title }}
+  {{ else if eq .Params.type "products" }}
+  {{ $product := partial "helpers/get-product" . }}
+  {{ $pageTitle = printf "%s | %v" $product.Title site.Title }}
   {{ end }}
   <title>{{ $pageTitle }}</title>
   {{ partial "baseof/head-top.html" . }}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -13,11 +13,11 @@
   {{ $pageTitle := site.Title }}
   {{ if .Params.seotitle }}
   {{ $pageTitle = .Params.seotitle }}
-  {{ else if .Title }}
-  {{ $pageTitle = .Title }}
-  {{ else if eq .Params.type "products" }}
+  {{ else if in .RelPermalink "products" }}
   {{ $product := partial "helpers/get-product" . }}
   {{ $pageTitle = printf "%s | %v" $product.Title site.Title }}
+  {{ else if .Title }}
+  {{ $pageTitle = printf "%v | %v" .Title site.Title }}
   {{ end }}
   <title>{{ $pageTitle }}</title>
   {{ partial "baseof/head-top.html" . }}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -14,10 +14,7 @@
   {{ if .Params.seotitle }}
   {{ $pageTitle = .Params.seotitle }}
   {{ else if .Title }}
-  {{ $pageTitle = printf "%v | %v" .Title site.Title }}
-  {{ else if eq .Params.type "products" }}
-  {{ $product := partial "helpers/get-product" . }}
-  {{ $pageTitle = printf "%s | %v" $product.Title site.Title }}
+  {{ $pageTitle = printf "%s | %s" .Title site.Title }}
   {{ end }}
   <title>{{ $pageTitle }}</title>
   {{ partial "baseof/head-top.html" . }}


### PR DESCRIPTION
# Why?

Right now, we currently have a place to put the Meta Description, but not Meta Titles. These need to be different than the H1 on the page. Right now, it's supposed to pull in from Shopify but oftentimes does not.

# How?
-added correct field to forestry front matter template  seo properties
-title now is conditionally rendered in following order: 
1. use seotitle field
2. if seotitle is empty, use title of page/collection/product. this is printed like so: "Coffee Bean Shimmer | Reima USA"
