### PR TITLE
Feat(forestry): Add alt text field/attribute to images on cms/theme

### DIFF
--- a/.forestry/front_matter/templates/hero.yml
+++ b/.forestry/front_matter/templates/hero.yml
@@ -36,6 +36,13 @@ fields:
   showOnly:
     field: type
     value: Image
+- name: image_alt
+  type: text
+  config:
+    required: false
+  label: Image Alt Text
+  description: An alternative text field to images for SEO and accessibility purposes.
+    Should convey what the image is about.
 - name: youtubeid
   type: text
   config:

--- a/.forestry/front_matter/templates/image-grid.yml
+++ b/.forestry/front_matter/templates/image-grid.yml
@@ -17,6 +17,13 @@ fields:
     config:
       maxSize: 64
     label: Image
+  - name: image_alt
+    type: text
+    config:
+      required: false
+    label: Image Alt Text
+    description: An alternative text field to images for SEO and accessibility purposes.
+      Should convey what the image is about.
   - name: content
     type: textarea
     default: ''

--- a/.forestry/front_matter/templates/image-links-small.yml
+++ b/.forestry/front_matter/templates/image-links-small.yml
@@ -26,6 +26,13 @@ fields:
     config:
       maxSize: 64
     label: Image
+  - name: image_alt
+    type: text
+    config:
+      required: false
+    label: Image Alt Text
+    description: An alternative text field to images for SEO and accessibility purposes.
+      Should convey what the image is about.
   config:
     min: 1
     max: 

--- a/.forestry/front_matter/templates/image-links.yml
+++ b/.forestry/front_matter/templates/image-links.yml
@@ -32,6 +32,13 @@ fields:
       maxSize: 64
     label: Image for mobile
     description: Image for use on mobile. Recommended aspect ratio is 1:1.
+  - name: image_alt
+    type: text
+    config:
+      required: false
+    label: Image Alt Text
+    description: An alternative text field to images for SEO and accessibility purposes.
+      Should convey what the image is about.
   - name: link
     type: text
     config:

--- a/.forestry/front_matter/templates/milestones.yml
+++ b/.forestry/front_matter/templates/milestones.yml
@@ -27,6 +27,13 @@ fields:
     config:
       maxSize: 64
     label: Image
+  - name: image_alt
+    type: text
+    config:
+      required: false
+    label: Image Alt Text
+    description: An alternative text field to images for SEO and accessibility purposes.
+      Should convey what the image is about.
   - name: link
     type: text
     config:

--- a/.forestry/front_matter/templates/split-card.yml
+++ b/.forestry/front_matter/templates/split-card.yml
@@ -8,6 +8,13 @@ fields:
   config:
     maxSize: 64
   label: Image
+- name: image_alt
+  type: text
+  config:
+    required: false
+  label: Image Alt Text
+  description: An alternative text field to images for SEO and accessibility purposes.
+    Should convey what the image is about.
 - name: subheading
   type: text
   config:

--- a/layouts/partials/img.html
+++ b/layouts/partials/img.html
@@ -14,10 +14,10 @@
     Sizes attribute for the img
 
  -->
-
+{{$alt := .alt}}
 {{- with trim .image "/" }}
 {{- with partial "helpers/get-image" . }}
-{{- partial "image" (dict "image" . "widths" $.widths "sizes" $.sizes) }}
+{{- partial "image" (dict "image" . "widths" $.widths "sizes" $.sizes "alt" $alt ) }}
 {{- else }}
 {{- warnf "Could not find image %s" . }}
 {{- end }}

--- a/layouts/partials/modules/hero.html
+++ b/layouts/partials/modules/hero.html
@@ -60,6 +60,7 @@
   {{- $mobile = partial "helpers/get-image" . }}
   {{- end }}
   <!-- get main image -->
+  {{- $image_alt := .image_alt }}
   {{- with .image }}
   {{- with partial "helpers/get-image" . }}
   {{- $params := (dict "image" . "widths" "2160,1080,768") }}
@@ -83,11 +84,11 @@
     {{- end }}
     <img class="lazyload" {{if $lazyload}} loading="lazy"
       srcset="data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20{{$default.Width}}%20{{$default.Height}}'></svg>"
-      {{end}} src="{{$default.RelPermalink}}" width="{{.Width}}" height="{{.Height}}" alt="" />
+      {{end}} src="{{$default.RelPermalink}}" width="{{.Width}}" height="{{.Height}}" alt="{{$image_alt}}" />
   </picture>
   <noscript>
     <img {{if $lazyload}}loading="lazy" {{end}} srcset="{{partial "srcset" $params}}" src="{{$default.RelPermalink}}"
-      height="{{.Height}}" width="{{.Width}}" alt="" />
+      height="{{.Height}}" width="{{.Width}}" alt="{{$image_alt}}" />
   </noscript>
   {{- end }}
   {{- else }}

--- a/layouts/partials/modules/image-grid.html
+++ b/layouts/partials/modules/image-grid.html
@@ -74,7 +74,7 @@
 
     <li>
       <a class="image-grid__container" href="#{{$modal_id}}" onclick="document.body.style.overflow = 'hidden'">
-        {{- partial "img" (dict "image" .image "widths" "300,600" "sizes" $sizes) }}
+        {{- partial "img" (dict "image" .image "widths" "300,600" "sizes" $sizes "alt" .image_alt) }}
       </a>
       <aside class="image-grid__modal" id="{{$modal_id}}">
         <a href="#/" tabindex="-1" onclick="document.body.style.overflow = ''"></a>
@@ -86,7 +86,7 @@
             </svg>
           </a>
           {{ $sizes_popup := "(min-width: 580px) 50vw, 100vw" }}
-          {{- partial "img" (dict "image" .image "widths" "300,600" "sizes" $sizes_popup) }}
+          {{- partial "img" (dict "image" .image "widths" "300,600" "sizes" $sizes_popup "alt" .image_alt) }}
           <div>
             {{- with .content }}
             {{. | $.pageobj.RenderString}}
@@ -101,7 +101,7 @@
       <a href="{{ .link }}">
       {{ end }}
       <div class="image-grid__container">
-        {{- partial "img" (dict "image" .image "widths" "300,600" "sizes" $sizes) }}
+        {{- partial "img" (dict "image" .image "widths" "300,600" "sizes" $sizes "alt" .image_alt) }}
       </div>
       {{- with .content }}
       {{. | $.pageobj.RenderString}}

--- a/layouts/partials/modules/image-links-small.html
+++ b/layouts/partials/modules/image-links-small.html
@@ -30,7 +30,7 @@
         fix image width to 120px
        -->
         {{ $sizes := "158px" }}
-        {{ partial "img" (dict "image" .image "widths" "158,316" "sizes" $sizes) }}
+        {{ partial "img" (dict "image" .image "widths" "158,316" "sizes" $sizes "alt" .image_alt) }}
       <span class="title">{{ .title }}</span>
       </a>
     </div>

--- a/layouts/partials/modules/image-links.html
+++ b/layouts/partials/modules/image-links.html
@@ -41,6 +41,7 @@
       {{- $mobile = partial "helpers/get-image" . }}
       {{- end }}
       <!-- get main image -->
+      {{- $image_alt := .image_alt }}
       {{- with .image }}
       {{- with partial "helpers/get-image" . }}
       {{- $params := (dict "image" . "widths" "375,768,1080") }}
@@ -55,11 +56,11 @@
         <img
           src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 {{.Width}} {{.Height}}'%3E%3C/svg%3E"
           class="lazyload" loading="lazy" alt="" data-srcset="{{partial "srcset" $params}}"
-          data-src="{{$default.RelPermalink}}" sizes="(min-width: 768px) {{$sizes}}, 100vw" />
+          data-src="{{$default.RelPermalink}}" sizes="(min-width: 768px) {{$sizes}}, 100vw" alt="{{$image_alt}}" />
       </picture>
       <noscript>
         <img loading="lazy" srcset="{{partial "srcset" $params}}" src="{{$default.RelPermalink}}" height="{{.Height}}"
-          width="{{.Width}}" alt="" />
+          width="{{.Width}}" alt="{{$image_alt}}" />
       </noscript>
       {{ end }}
       {{- else }}

--- a/layouts/partials/modules/milestones.html
+++ b/layouts/partials/modules/milestones.html
@@ -2,6 +2,7 @@
     <h3 class="h4">{{.heading}}</h3>
     <ol class="milestones__about-timeline">
         {{ range .milestones }}
+        {{ $image_alt := .image_alt}}
         <li>
             <div class="milestones__media">
                 <div class="milestones__media-left">
@@ -13,7 +14,7 @@
                             {{(.Fill "100x100").RelPermalink}} 100w,
                             {{(.Fill "200x200").RelPermalink}} 200w"
                             sizes="(min-width: 768px) 100px, 70px"
-                            data-src="{{(.Fill "100x100").RelPermalink}}" alt="" />
+                            data-src="{{(.Fill "100x100").RelPermalink}}" alt="{{$image_alt}}" />
                         {{ end }}
                     </div>
                 </div>

--- a/layouts/partials/modules/split-card.html
+++ b/layouts/partials/modules/split-card.html
@@ -10,7 +10,7 @@
 {{ end }}
 <section class="{{$class}}">
   {{ $sizes := "(min-width: 768px) min(620px, 50vw), 100vw" }}
-  {{partial "img" (dict "image" .image "widths" "375,750" "sizes" $sizes)}}
+  {{partial "img" (dict "image" .image "widths" "375,750" "sizes" $sizes "alt" .image_alt)}}
   <div>
     {{ if or .heading .subheading }}
     <header>


### PR DESCRIPTION
# Why?

This helps from not only an SEO standpoint but also an ADA standpoint in the US (American Disabilities Act) where the alt text reads out what the images look like to the visually impaired.

# How?

Added alt text field to front matter templates with an image on forestry.
Added alt attribute to corresponding modules in theme
Added alt attribute to image partials