### PR TITLE
fix(pdp-price): strikethrough price shows only if it exists

### DIFF
--- a/layouts/partials/product.ts
+++ b/layouts/partials/product.ts
@@ -60,8 +60,8 @@ const getVariant = (options: Options) =>
     return Object.keys(v.options).every((k) => options[k] === v.options[k]);
   });
 
-const inputChange = (e: Event) => {
-  const previousVariant = getVariant(selectedOptions);
+  const inputChange = (e: Event) => {
+    const previousVariant = getVariant(selectedOptions);
   const { name, value } = e.currentTarget as HTMLInputElement;
   selectedOptions[name] = value;
   // check if available
@@ -83,13 +83,13 @@ const inputChange = (e: Event) => {
       {},
       selectedOptions,
       { [radio.name]: radio.value },
-    );
-    const thisVariant = getVariant(thisSelection);
+      );
+      const thisVariant = getVariant(thisSelection);
     const thisLabel = document.querySelector(`label[for="${radio.id}"]`)!;
     if (thisVariant && thisVariant.available) {
       thisLabel.classList.remove("unavailable");
     } else thisLabel.classList.add("unavailable");
-  });
+  }); 
   // set selected span text
   document.getElementById(`selected-${name}`)!.innerText = value;
   if (variant) {
@@ -107,10 +107,11 @@ const inputChange = (e: Event) => {
         priceElement.classList.remove("price--sale");
       });
     }
-    document.querySelector<HTMLElement>(".price--was")!.innerText =
-      variant.compareAtPriceFormatted
-        ? renderPrice(variant.compareAtPriceFormatted)
-        : "";
+    const priceWasElements = document.querySelectorAll<HTMLElement>(".price--was")!;
+    priceWasElements.forEach((priceWasElement) => {
+      const priceWas = variant.compareAtPriceFormatted ? renderPrice(variant.compareAtPriceFormatted) : "";
+      return priceWasElement.innerText = priceWas;
+    });
     // change product image if needed
     if (previousVariant && previousVariant.imagePath !== variant.imagePath) {
       const carouselSelector = form.dataset.productImages;


### PR DESCRIPTION
# Why?
Strikethrough price is displayed on PDP for all color variants if the first variant is discounted

# How?
Looped over all elements as there are 2 different price elements, for mobile and desktop. Earlier code only selected the first element (mobile)

closes #329 