### PR TITLE
Feat(alt text): defaults to image name

### DIFF
--- a/layouts/partials/carousel.html
+++ b/layouts/partials/carousel.html
@@ -2,6 +2,11 @@
     <ul>
         {{ range $index, $slide := .slides }}
         <li class="carousel__item" data-id="item-{{ add $index 1}}">
+            <!--  Create alt text, defaults to image filename if no specified alt text -->
+            {{- $alt := partial "helpers/humanize-image-filename.html" $slide.image}}
+            {{- if .image_alt}}
+            {{- $alt = .image_alt}}
+            {{- end}}
             <!-- get mobile image if exists -->
             {{- $mobile := false }}
             {{- with .imagemobile }}
@@ -20,12 +25,12 @@
                 <source srcset="{{partial "srcset" (dict "image" . "widths" "1080,768")}}">
                 {{- end }}
                 <img
-                        src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 {{.Width}} {{.Height}}'%3E%3C/svg%3E"
-                        class="lazyload" loading="lazy" alt="" data-srcset="{{partial "srcset" $params}}"
-                data-src="{{$default.RelPermalink}}" sizes="(min-width: 768px) {{$sizes}}, 100vw" />
+                    src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 {{.Width}} {{.Height}}'%3E%3C/svg%3E"
+                    class="lazyload" loading="lazy" alt="{{$alt}}" data-srcset="{{partial "srcset" $params}}"
+                    data-src="{{$default.RelPermalink}}" sizes="(min-width: 768px) {{$sizes}}, 100vw" />
             </picture>
             <noscript>
-                <img loading="lazy" alt="" srcset="{{partial "srcset" $params}}" src="{{$default.RelPermalink}}" height="{{.Height}}"
+                <img loading="lazy" alt="{{$alt}}" srcset="{{partial "srcset" $params}}" src="{{$default.RelPermalink}}" height="{{.Height}}"
                 width="{{.Width}}" />
             </noscript>
             {{ end }}

--- a/layouts/partials/elements/benefits.html
+++ b/layouts/partials/elements/benefits.html
@@ -1,33 +1,35 @@
-{{ if .benefitsEnabled }}
-
-{{ with .benefits }}
+{{- if .benefitsEnabled }}
+{{- with .benefits }}
 <section class="benefits">
   <div class="container">
-    {{ range .links }}
+    {{- range .links }}
     <a href="{{partial "helpers/get-link" (dict "url" .url "context" "benefit bar links")}}" class="benefit">
       <div class="icon">
-        {{ if .icon }}
-        {{ $img := partial "helpers/get-image" .icon }}
+        {{- if .icon }}
+        <!-- Create alt text from image filename -->
+        {{- $alt := partial "helpers/humanize-image-filename.html" .icon}}
         <!-- check if this is png or jpeg and resize if it is -->
-        {{ if or (eq $img.MediaType.SubType "png") (eq $img.MediaType.SubType "jpeg")}}
-        {{ $onex := $img.Resize (printf "%dx" .width) }}
-        {{ $twox := $img.Resize (printf "%dx" (mul .width 2)) }}
-        <img srcset="{{$onex.RelPermalink}} 1x, {{$twox.RelPermalink}} 2x" src="{{$onex.RelPermalink}}" alt=""
+        {{- $img := partial "helpers/get-image" .icon }}
+        <!-- check if this is png or jpeg and resize if it is -->
+        {{- if or (eq $img.MediaType.SubType "png") (eq $img.MediaType.SubType "jpeg")}}
+        {{- $onex := $img.Resize (printf "%dx" .width) }}
+        {{- $twox := $img.Resize (printf "%dx" (mul .width 2)) }}
+        <img srcset="{{$onex.RelPermalink}} 1x, {{$twox.RelPermalink}} 2x" src="{{$onex.RelPermalink}}" alt="{{$alt}}"
              width="{{$onex.Width}}" height="{{$onex.Height}}">
         <!-- if some other type (like svg), just output directly -->
-        {{ else }}
-        <img src="{{$img.RelPermalink}}" alt="" width="{{.width}}"{{with .height}} height="{{.}}"{{end}}>
-        {{ end }}
-        {{ end }}
+        {{- else }}
+        <img src="{{$img.RelPermalink}}" alt="{{$alt}}" width="{{.width}}"{{with .height}} height="{{.}}"{{end}}>
+        {{- end }}
+        {{- end }}
       </div>
       <h3 class="heading">{{.heading}}</h3>
       <span class="cta">{{.text}}</span>
     </a>
-    {{ end }}
+    {{- end }}
   </div>
 </section>
-{{ else }}
-{{ warnf "Benefits not found for %s" site.Language }}
-{{ end }}
+{{- else }}
+{{- warnf "Benefits not found for %s" site.Language }}
+{{- end }}
 
-{{ end }}
+{{- end }}

--- a/layouts/partials/helpers/humanize-image-filename.html
+++ b/layouts/partials/helpers/humanize-image-filename.html
@@ -1,0 +1,11 @@
+<!-- remove suffix & humanize image filename -->
+{{- $image_name := . }}
+{{- if strings.HasSuffix . "jpg" }}
+{{- $image_name = strings.TrimSuffix ".jpg" . }} 
+{{- else if strings.HasSuffix . "svg" }}
+{{- $image_name = strings.TrimSuffix ".svg" . }} 
+{{- else if strings.HasSuffix . "png" }}
+{{- $image_name = strings.TrimSuffix ".png" . }} 
+{{- end }}
+{{- $image_name = humanize $image_name}}
+{{- return $image_name }}

--- a/layouts/partials/image.html
+++ b/layouts/partials/image.html
@@ -15,6 +15,7 @@
 
   - [alt]
     Alternative text - HIGHLY RECOMMENDED
+    defaults to humanized image filename if no specified alt text
 
   - [class]
     Optionally add this class to the element
@@ -22,17 +23,25 @@
   - [dataset]
     Optional map of items to add to dataset
  -->
+
+{{- $alt := partial "helpers/humanize-image-filename.html" .image.Name}}
+{{- if .alt}}
+{{- $alt = .alt}}
+{{- end}}
+
+ <script>console.log("$alt: ",{{$alt}})</script>
 {{- $width := index (split $.widths ",") 0 -}}
 {{- $default := .image.Resize (printf "%sx" $width) -}}
 {{- if not .sizes }}
 {{- warnf "`sizes` attribute missing for image %s" .image.RelPermalink }}
 {{- end }}
+
 <img
   src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 {{$default.Width}} {{$default.Height}}'%3E%3C/svg%3E"
   loading="lazy" data-srcset="{{partial "srcset" $}}" data-src="{{$default.RelPermalink}}" height="{{.image.Height}}"
-  width="{{.image.Width}}" class="lazyload {{.class}}" {{with .sizes}}sizes="{{.}}" {{end}} alt="{{.alt}}"
+  width="{{.image.Width}}" class="lazyload {{.class}}" {{with .sizes}}sizes="{{.}}" {{end}} alt="{{$alt}}"
   {{range $key, $val := .dataset}}data-{{$key}}="{{$val}}" {{end}} />
 <noscript>
   <img loading="lazy" srcset="{{partial "srcset" $}}" src="{{$default.RelPermalink}}" height="{{.image.Height}}"
-    width="{{.image.Width}}" class="{{.class}}" {{with .sizes}}sizes="{{.}}" {{end}} alt="{{.alt}}" />
+    width="{{.image.Width}}" class="{{.class}}" {{with .sizes}}sizes="{{.}}" {{end}} alt="{{$alt}}" />
 </noscript>

--- a/layouts/partials/image.html
+++ b/layouts/partials/image.html
@@ -25,7 +25,9 @@
  -->
 
 {{- $alt := partial "helpers/humanize-image-filename.html" .image.Name}}
-{{- if .alt}}
+{{- if .image.Title}}
+{{- $alt = partial "helpers/humanize-image-filename.html" .image.Title}}
+{{- else if .alt}}
 {{- $alt = .alt}}
 {{- end}}
 

--- a/layouts/partials/image.html
+++ b/layouts/partials/image.html
@@ -29,7 +29,6 @@
 {{- $alt = .alt}}
 {{- end}}
 
- <script>console.log("$alt: ",{{$alt}})</script>
 {{- $width := index (split $.widths ",") 0 -}}
 {{- $default := .image.Resize (printf "%sx" $width) -}}
 {{- if not .sizes }}

--- a/layouts/partials/img.html
+++ b/layouts/partials/img.html
@@ -14,10 +14,11 @@
     Sizes attribute for the img
 
  -->
-{{$alt := .alt}}
+{{- $alt := .alt}}
+
 {{- with trim .image "/" }}
 {{- with partial "helpers/get-image" . }}
-{{- partial "image" (dict "image" . "widths" $.widths "sizes" $.sizes "alt" $alt ) }}
+{{- partial "image" (dict "image" . "widths" $.widths "sizes" $.sizes "alt" $alt) }}
 {{- else }}
 {{- warnf "Could not find image %s" . }}
 {{- end }}

--- a/layouts/partials/modules/hero.html
+++ b/layouts/partials/modules/hero.html
@@ -59,8 +59,12 @@
   {{- with .imagemobile }}
   {{- $mobile = partial "helpers/get-image" . }}
   {{- end }}
+  <!--  Create alt text, defaults to image filename if no specified alt text -->
+  {{- $alt := partial "helpers/humanize-image-filename.html" .image}}
+  {{- if .image_alt}}
+  {{- $alt = .image_alt}}
+  {{- end}}
   <!-- get main image -->
-  {{- $image_alt := .image_alt }}
   {{- with .image }}
   {{- with partial "helpers/get-image" . }}
   {{- $params := (dict "image" . "widths" "2160,1080,768") }}
@@ -84,11 +88,11 @@
     {{- end }}
     <img class="lazyload" {{if $lazyload}} loading="lazy"
       srcset="data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20{{$default.Width}}%20{{$default.Height}}'></svg>"
-      {{end}} src="{{$default.RelPermalink}}" width="{{.Width}}" height="{{.Height}}" alt="{{$image_alt}}" />
+      {{end}} src="{{$default.RelPermalink}}" width="{{.Width}}" height="{{.Height}}" alt="{{$alt}}" />
   </picture>
   <noscript>
     <img {{if $lazyload}}loading="lazy" {{end}} srcset="{{partial "srcset" $params}}" src="{{$default.RelPermalink}}"
-      height="{{.Height}}" width="{{.Width}}" alt="{{$image_alt}}" />
+      height="{{.Height}}" width="{{.Width}}" alt="{{$alt}}"/>
   </noscript>
   {{- end }}
   {{- else }}

--- a/layouts/partials/modules/image-links.html
+++ b/layouts/partials/modules/image-links.html
@@ -40,8 +40,12 @@
       {{- with .imagemobile }}
       {{- $mobile = partial "helpers/get-image" . }}
       {{- end }}
+      <!--  Create alt text, defaults to image filename if no specified alt text -->
+      {{- $alt := partial "helpers/humanize-image-filename.html" .image}}
+      {{- if .image_alt}}
+      {{- $alt = .image_alt}}
+      {{- end}}
       <!-- get main image -->
-      {{- $image_alt := .image_alt }}
       {{- with .image }}
       {{- with partial "helpers/get-image" . }}
       {{- $params := (dict "image" . "widths" "375,768,1080") }}
@@ -55,12 +59,12 @@
         {{- end }}
         <img
           src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 {{.Width}} {{.Height}}'%3E%3C/svg%3E"
-          class="lazyload" loading="lazy" alt="" data-srcset="{{partial "srcset" $params}}"
-          data-src="{{$default.RelPermalink}}" sizes="(min-width: 768px) {{$sizes}}, 100vw" alt="{{$image_alt}}" />
+          class="lazyload" loading="lazy" data-srcset="{{partial "srcset" $params}}"
+          data-src="{{$default.RelPermalink}}" sizes="(min-width: 768px) {{$sizes}}, 100vw" alt="{{$alt}}" />
       </picture>
       <noscript>
         <img loading="lazy" srcset="{{partial "srcset" $params}}" src="{{$default.RelPermalink}}" height="{{.Height}}"
-          width="{{.Width}}" alt="{{$image_alt}}" />
+          width="{{.Width}}" alt="{{$alt}}" />
       </noscript>
       {{ end }}
       {{- else }}

--- a/layouts/partials/modules/milestones.html
+++ b/layouts/partials/modules/milestones.html
@@ -1,36 +1,40 @@
 <section id="milestones" class="milestones content-container-mobile">
     <h3 class="h4">{{.heading}}</h3>
     <ol class="milestones__about-timeline">
-        {{ range .milestones }}
-        {{ $image_alt := .image_alt}}
+        {{- range .milestones }}
+        <!--  Create alt text, defaults to image filename if no specified alt text -->
+        {{- $alt := partial "helpers/humanize-image-filename.html" .image}}
+        {{- if .image_alt}}
+        {{- $alt = .image_alt}}
+        {{- end}}
         <li>
             <div class="milestones__media">
                 <div class="milestones__media-left">
                     <div class="milestones__about-timeline-img">
-                        {{ with partial "helpers/get-image" .image }}
+                        {{- with partial "helpers/get-image" .image }}
                             <img class="lazyload" loading="lazy"
                             data-srcset="{{(.Fill "70x70").RelPermalink}} 70w,
                             {{(.Fill "140x140").RelPermalink}} 140w,
                             {{(.Fill "100x100").RelPermalink}} 100w,
                             {{(.Fill "200x200").RelPermalink}} 200w"
                             sizes="(min-width: 768px) 100px, 70px"
-                            data-src="{{(.Fill "100x100").RelPermalink}}" alt="{{$image_alt}}" />
+                            data-src="{{(.Fill "100x100").RelPermalink}}" alt="{{$alt}}" />
                         {{ end }}
                     </div>
                 </div>
                 <div class="milestones__media-body milestones__media-middle">
                     <div class="milestones__about-timeline-year">{{.year}}</div>
-                    {{ with .heading }}
+                    {{- with .heading }}
                     <h5 class="milestones__about-timeline-heading">{{.}}</h5>
-                    {{ end }}
-                    {{ with .text }}
+                    {{- end }}
+                    {{- with .text }}
                     <p class="milestones__about-timeline-text">{{.}}</p>
-                    {{ end }}
-                    {{ if .link }}
+                    {{- end }}
+                    {{- if .link }}
                     <a href="{{partial "helpers/get-link-module" (slice .link $)}}" {{if .externalLink}}target="_blank" {{end}}
                         class="{{if .externalLink}}milestones__external-link{{end}} {{if .stretchedLink}}stretched-link{{end}}">
-                        {{.linktext}}
-                        {{ if .externalLink }}
+                        {{- .linktext }}
+                        {{- if .externalLink }}
                         <span class="milestones__external-link-icon">
                             <svg viewBox="0 0 32 32">
                                 <path
@@ -38,12 +42,12 @@
                                 </path>
                             </svg>
                         </span>
-                        {{ end }}
+                        {{- end }}
                     </a>
-                    {{ end }}
+                    {{- end }}
                 </div>
             </div>
         </li>
-        {{ end }}
+        {{- end }}
     </ol>
 </section>

--- a/layouts/partials/modules/testimonials.html
+++ b/layouts/partials/modules/testimonials.html
@@ -6,7 +6,7 @@
     {{ range .testimonials }}
     <div>
       <blockquote{{with .link}} cite="{{.}}" {{end}}>
-        <img src="{{(resources.Get "reima-friends-quote-gray.svg").RelPermalink}}" alt='"'>
+        <img src="{{(resources.Get "reima-friends-quote-gray.svg").RelPermalink}}" alt="icon quote">
         <div>{{.text | $.pageobj.RenderString}}</div>
         <footer>
           {{.author}}

--- a/layouts/partials/product.html
+++ b/layouts/partials/product.html
@@ -18,9 +18,9 @@
     </h1>
     <div class="product-prices">
       {{ with $firstAvailableVariant }}
-      {{partial "product-price" .}}
+      {{ partial "product-price" . }}
       {{ else }}
-      {{partial "product-price" .Params}}
+      {{ partial "product-price" .Params }}
       {{ end }}
       {{ with partial "helpers/get-reviews-bottomline" $product.Params.yotpoId }}
       <div>
@@ -38,14 +38,15 @@
     <r-carousel>
       <div>
         <!-- sizes: roughly 100vw up to 768px, 40vw but max 536px after that -->
-        {{ $sizes := "(min-width: 768px) min(40vw, 536px), 100vw" }}
-        {{ with index $imgs 0 }}
+        {{- $sizes := "(min-width: 768px) min(40vw, 536px), 100vw" }}
+        {{- with index $imgs 0 }}
+        {{- $alt := partial "helpers/humanize-image-filename.html" .Title}}
         <img srcset="{{partial "srcset" (dict "image" . "widths" "375,750")}}" src="{{(.Resize "375x").RelPermalink}}"
-          height="{{.Height}}" width="{{.Width}}" sizes="{{$sizes}}" data-path="{{.Name}}" alt="" />
-        {{ end }}
-        {{ range $i, $img := after 1 $imgs }}
-        {{partial "image" (dict "image" . "widths" "375,750" "sizes" $sizes "dataset" (dict "path" .Name))}}
-        {{ end }}
+          height="{{.Height}}" width="{{.Width}}" sizes="{{$sizes}}" data-path="{{.Name}}" alt="{{$alt}}" />
+        {{- end }}
+        {{- range $i, $img := after 1 $imgs }}
+        {{- partial "image" (dict "image" . "widths" "375,750" "sizes" $sizes "dataset" (dict "path" .Name))}}
+        {{- end }}
       </div>
       {{ if gt (len $imgs) 1 }}
       <button prev></button>


### PR DESCRIPTION
#Why
Use image name as alt text, if alt is empty in Forestry/Shopify 

#How
Created a new partial that [humanizes](https://gohugo.io/functions/humanize/) image filenames and img alt text defaults to this if no defined alt present from Forestry and Shopify.