### PR TITLE
feat(hero-vimeo-mobile): mobile version of vimeo video

### DIFF
--- a/.forestry/front_matter/templates/hero.yml
+++ b/.forestry/front_matter/templates/hero.yml
@@ -43,6 +43,9 @@ fields:
   label: Image Alt Text
   description: An alternative text field to images for SEO and accessibility purposes.
     Should convey what the image is about.
+  showOnly:
+    field: type
+    value: Image
 - name: youtubeid
   type: text
   config:
@@ -84,6 +87,54 @@ fields:
     required: false
   label: Vimeo ID
   description: E.g. <code>448635405</code>, which can be found in the URL (https://vimeo.com/448635405)
+  showOnly:
+    field: type
+    value: Vimeo Video
+- name: vimeo_aspect_ratio
+  type: select
+  default: ''
+  config:
+    required: false
+    options:
+    - '3:2'
+    - '4:3'
+    - '5:4'
+    - '16:9'
+    - '1:1'
+    source:
+      type: simple
+      section: 
+      file: 
+      path: 
+  label: Vimeo aspect ratio
+  showOnly:
+    field: type
+    value: Vimeo Video
+- name: vimeoid_mobile
+  type: text
+  config:
+    required: false
+  label: Vimeo ID mobile
+  description: This video overrides Vimeo ID on mobile
+  showOnly:
+    field: type
+    value: Vimeo Video
+- name: vimeo_aspect_ratio_mobile
+  type: select
+  default: ''
+  config:
+    required: false
+    options:
+    - '3:2'
+    - '16:10'
+    - '9:16'
+    - '1:1'
+    source:
+      type: simple
+      section: 
+      file: 
+      path: 
+  label: Vimeo aspect ratio mobile
   showOnly:
     field: type
     value: Vimeo Video

--- a/.forestry/front_matter/templates/hero.yml
+++ b/.forestry/front_matter/templates/hero.yml
@@ -96,11 +96,10 @@ fields:
   config:
     required: false
     options:
-    - '3:2'
-    - '4:3'
-    - '5:4'
-    - '16:9'
     - '1:1'
+    - '4:5'
+    - '9:16'
+    - '16:9'
     source:
       type: simple
       section: 
@@ -125,10 +124,10 @@ fields:
   config:
     required: false
     options:
-    - '3:2'
-    - '16:10'
-    - '9:16'
     - '1:1'
+    - '4:5'
+    - '9:16'
+    - '16:9'
     source:
       type: simple
       section: 

--- a/layouts/partials/helpers/get-video-padding.html
+++ b/layouts/partials/helpers/get-video-padding.html
@@ -1,0 +1,4 @@
+   <!-- Splits the given aspect ratio string and returns a string of the 2/1 * 100   -->
+  {{- $split := split . ":"}}
+  {{- $divided := mul (div (float (index ($split) 1)) (float (index ($split) 0))) 100 }}
+  {{- return printf "%s%%" (string ($divided)) }}

--- a/layouts/partials/modules/hero.css
+++ b/layouts/partials/modules/hero.css
@@ -93,8 +93,8 @@
   width:100%;
 }
 
+
 .hero__video-container::after {
-  padding-top: 56.25%;
   display: block;
   content: '';
 }
@@ -105,6 +105,16 @@
   left: 0;
   width: 100%;
   height: 100%;
+}
+@media (max-width: 767px) {
+  .hero__video-container.with-mobile {
+    display: none;
+  }
+}
+@media (min-width: 768px) {
+  .hero__video-container.mobile {
+    display: none;
+  }
 }
 
 .hero--overlay-mobile.hero--overlay-bg .hero__text {

--- a/layouts/partials/modules/hero.html
+++ b/layouts/partials/modules/hero.html
@@ -30,9 +30,10 @@
 {{ $class = printf "%s hero--yellow-emphasis" $class }}
 {{ end }}
 <div class="{{$class}}">
+  <!-- default padding-top for videos -->
+  {{- $padding_top := "56.25%" }}
   {{- if eq .type "Youtube Video" }}
-
-  <div class="hero__video-container">
+  <div class="hero__video-container" style="padding-top: {{$padding_top}};">
     {{- $src := printf "https://www.youtube.com/embed/%s" .youtubeid }}
     {{- $qry := slice }}
     {{- if .youtubeautoplay }}{{ $qry = $qry | append "autoplay=1" }}{{end}}
@@ -44,11 +45,27 @@
   </div>
 
   {{- else if eq .type "Vimeo Video" }}
+  {{- $vimeobg := .vimeobg}}
+  {{- $padding_top_mobile := $padding_top}}
+  <!-- if Vimeo mobile aspect ratio is defined -->
+  {{- with .vimeo_aspect_ratio_mobile }}
+  {{- $padding_top_mobile = partial "helpers/get-video-padding" .}}
+  {{- end }}
+  <!-- if Vimeo aspect ratio is defined -->
+  {{- with .vimeo_aspect_ratio }}
+  {{- $padding_top = partial "helpers/get-video-padding" .}}
+  {{- end }}
 
-  <div class="hero__video-container">
-    <iframe src="https://player.vimeo.com/video/{{.vimeoid}}{{if .vimeobg}}?background=1{{end}}" width="640"
-      height="360" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
+  <!-- Vimeo iframe desktop, default.  -->
+  <div class="hero__video-container vimeo {{with .vimeoid_mobile}}with-mobile{{end}}" style="padding-top: {{$padding_top}};">
+    <iframe src="https://player.vimeo.com/video/{{.vimeoid}}{{if .vimeobg}}?background=1{{end}}" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
   </div>
+  <!-- Vimeo iframe mobile, renders only in devices under 768px width -->
+  {{- with .vimeoid_mobile}}
+  <div class="hero__video-container vimeo mobile" style="padding-top: {{$padding_top_mobile}};">
+    <iframe src="https://player.vimeo.com/video/{{.}}{{if $vimeobg}}?background=1{{end}}" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
+  </div>
+  {{- end}}
 
   {{- else }}
 


### PR DESCRIPTION
#Why
Current setup in hero only accommodates certain aspect ratio videos for Vimeo and no option for specific mobile video. iframe needs to have a fixed padding according to the video aspect ratio.

#How

- Created Forestry fields for aspect ratio and vimeo id mobile.
- Added functionality to hero module, that conditionally renders videos according to created fields and generates a padding top from from the aspect ratio