### PR TITLE
fix(search-filter): hide close button on desktop

### DIFF
--- a/layouts/_default/search.css
+++ b/layouts/_default/search.css
@@ -20,6 +20,7 @@ main {
     --z-index: unset;
     --filters-padding: var(--content-padding) var(--content-padding) 0 0;
     --filter-selection-btn-show: block;
+    --close-btn-show: none;
   }
 }
 


### PR DESCRIPTION
## Why 
search filter close button was displayed when filter selections was focused on desktop

## How 
display: none; on close button desktop width