### PR TITLE
Fix(product carousel): product carousel mobile more button moved to under carousel 

### DIFF
--- a/layouts/partials/modules/products.css
+++ b/layouts/partials/modules/products.css
@@ -47,6 +47,10 @@
 .product-list__heading a {
   display: none;
 }
+.product-list__bottom {
+  display: flex;
+  justify-content: center;
+}
 
 .product-list__show-all {
   display: flex;
@@ -174,6 +178,10 @@
   }
 
   .product-list__show-all {
+    display: none;
+  }
+  
+  .product-list__bottom {
     display: none;
   }
 }

--- a/layouts/partials/modules/products.html
+++ b/layouts/partials/modules/products.html
@@ -77,12 +77,14 @@
     {{ warnf "Could not find product %s (%s %s %s)" .File.ContentBaseName .File.Dir .Kind .Type }}
     {{ end }}
     {{ end }}
+    {{ if (not $.carousel_enabled) }}
     {{ if gt $product_count (len $productPages)}}
     <li class="product-list__show-all">
       <a href="{{$collectionPage.RelPermalink}}" class="btn">
         {{default (T "Product list show all") $.show_all}}
       </a>
     </li>
+    {{ end }}
     {{ end }}
   </ul>
 
@@ -95,8 +97,12 @@
     <div aria-label="Previous image" class="prev">&lsaquo;</div>
     <div aria-label="Next image" class="next">&rsaquo;</div>
   </div>
+  <div class="product-list__bottom">
+    <a href="{{$collectionPage.RelPermalink}}" class="btn btn--sm">
+      {{default (T "Product list show all") $.show_all}}
+    </a>
+  </div>
   {{ end }}
-
 
   {{ else }}
   <p>No products found</p>

--- a/layouts/partials/modules/products.html
+++ b/layouts/partials/modules/products.html
@@ -97,11 +97,13 @@
     <div aria-label="Previous image" class="prev">&lsaquo;</div>
     <div aria-label="Next image" class="next">&rsaquo;</div>
   </div>
-  <div class="product-list__bottom">
-    <a href="{{$collectionPage.RelPermalink}}" class="btn btn--sm">
-      {{default (T "Product list show all") $.show_all}}
-    </a>
-  </div>
+    {{ if gt $product_count (len $productPages)}}
+    <div class="product-list__bottom">
+      <a href="{{$collectionPage.RelPermalink}}" class="btn btn--sm">
+        {{default (T "Product list show all") $.show_all}}
+      </a>
+    </div>
+    {{ end }}
   {{ end }}
 
   {{ else }}


### PR DESCRIPTION
## Why

"Show all" button is not visible with mobile product carousel immediately

## How

Conditional rendering in template of the "show all" button