### PR TITLE
feat(collection-filter):  option to hide product filter from collection page

### DIFF
--- a/.forestry/front_matter/templates/collection.yml
+++ b/.forestry/front_matter/templates/collection.yml
@@ -36,6 +36,11 @@ fields:
   config:
     min: 1
     max: 
+- name: filters
+  type: boolean
+  label: Filters
+  description: Show search filters for product lists on the collection page.
+  default: true
 - name: sidebar
   type: field_group_list
   fields:


### PR DESCRIPTION
## Why
We use multiple lists per page, i.e. to add content blocks between lists. In those cases it makes the multiple floating filters appear at the same time and the results are unnecessary.

## How
Add a toggle on forestry and conditional that hides the filter