### PR TITLE
fix(collection-products): Remove custom URL from collection products

### DIFF
--- a/demo/products/collections/tops/products/juniors-sweater-vigur.md
+++ b/demo/products/collections/tops/products/juniors-sweater-vigur.md
@@ -3,6 +3,10 @@
   "type": "products",
   "weight": 74,
   "noindex": true,
-  "description": null
+  "description": null,
+  "_build": {
+    "list": true,
+    "render": false
+  }
 }
 ---

--- a/demo/products/collections/tops/products/juniors-sweater-vigur6.md
+++ b/demo/products/collections/tops/products/juniors-sweater-vigur6.md
@@ -3,6 +3,10 @@
   "type": "products",
   "weight": 74,
   "noindex": true,
-  "description": null
+  "description": null,
+  "_build": {
+    "list": true,
+    "render": false
+  }
 }
 ---

--- a/demo/products/collections/tops/products/juniors-sweater-vigur7.md
+++ b/demo/products/collections/tops/products/juniors-sweater-vigur7.md
@@ -3,6 +3,10 @@
   "type": "products",
   "weight": 74,
   "noindex": true,
-  "description": null
+  "description": null,
+  "_build": {
+    "list": true,
+    "render": false
+  }
 }
 ---

--- a/demo/products/collections/tops/products/juniors-sweater-vigur8.md
+++ b/demo/products/collections/tops/products/juniors-sweater-vigur8.md
@@ -3,6 +3,10 @@
   "type": "products",
   "weight": 74,
   "noindex": true,
-  "description": null
+  "description": null,
+  "_build": {
+    "list": true,
+    "render": false
+  }
 }
 ---

--- a/demo/products/collections/tops/products/juniors-sweater-winged.md
+++ b/demo/products/collections/tops/products/juniors-sweater-winged.md
@@ -3,6 +3,10 @@
   "type": "products",
   "weight": 73,
   "noindex": true,
-  "description": null
+  "description": null,
+  "_build": {
+    "list": true,
+    "render": false
+  }
 }
 ---

--- a/demo/products/collections/tops/products/kids-sweater-mahin.md
+++ b/demo/products/collections/tops/products/kids-sweater-mahin.md
@@ -3,6 +3,10 @@
   "type": "products",
   "weight": 75,
   "noindex": true,
-  "description": null
+  "description": null,
+  "_build": {
+    "list": true,
+    "render": false
+  }
 }
 ---

--- a/importers/import-collections/content.ts
+++ b/importers/import-collections/content.ts
@@ -25,6 +25,11 @@ export type CollectionContent = Content<
   }
 >;
 
+export type buildOptions = {
+  list: boolean;
+  render: boolean;
+};
+
 export type CollectionProductContent = Content<
   "product",
   {
@@ -32,6 +37,7 @@ export type CollectionProductContent = Content<
     noindex: true;
     weight: number;
     title: string;
+    _build?: buildOptions | null;
   },
   { collection: CollectionHandle }
 >;
@@ -85,6 +91,10 @@ export const toCollectionProductContent = (
     type: "products",
     weight: counter,
     title: collectionProduct.title,
+    _build: {
+      list: true,
+      render: false
+    }
   },
 });
 

--- a/layouts/partials/modules/products.html
+++ b/layouts/partials/modules/products.html
@@ -57,9 +57,10 @@
   <ul data-collection="{{path.Base .File.Dir}}">
     <!-- loop through product pages -->
     {{ range $pageIndex, $page := $productPages  }}
-    {{ $linkresolved := partial "link" .RelPermalink }}
+
     {{ with site.GetPage (printf "/products/%s" .File.ContentBaseName) }}
     {{ $product := . }}
+    {{ $linkresolved := .RelPermalink }}
 
     {{ if $.split_colors }}
 


### PR DESCRIPTION
# Why?

Currently collection page products have unique URL and that multiplies rendering time.

# How?

Collection products pages won't be rendered any more and we will use just one URL for single product page.
