### PR TITLE
fix(split-card): Check .image before calling partial

### DIFF
--- a/layouts/partials/modules/split-card.html
+++ b/layouts/partials/modules/split-card.html
@@ -10,7 +10,7 @@
 {{ end }}
 <section class="{{$class}}">
   {{ $sizes := "(min-width: 768px) min(620px, 50vw), 100vw" }}
-  {{ if .image }}
+  {{ with .image }}
   {{partial "img" (dict "image" .image "widths" "375,750" "sizes" $sizes "alt" .image_alt)}}
   {{ end }}
   <div>


### PR DESCRIPTION
# Why?

split-card module is calling img partial without checking .image value and it could cause error.

# How?

Check .image value before calling link partial.
