### PR TITLE
Feat/netlify large media

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -89,12 +89,14 @@
   <!-- Open Graph image renders 1st image from .Resources but defaults to logo -->
   {{- with (index (.Resources.ByType "image") 0)}}
   {{- $image := . }}
-  {{- $image = $image.Fill "1200x630 q50" }}
-  <meta property="og:image" content="{{ $image.Permalink }}"/>
-  <meta property="og:image:secure_url" content="{{ $image.Permalink }}"/>
-  <meta property="og:image:width" content="{{ $image.Width }}"/>
-  <meta property="og:image:height" content="{{ $image.Height }}"/>
-  <meta name="twitter:image:src" content="{{ $image.Permalink }}"/> 
+  {{- $resize := "?nf_resize=fit&w=1200&h=630" }}
+  {{- $urlString := printf "%s%s" $image.Permalink $resize }}
+  
+  <meta property="og:image" content="{{ $urlString }}"/>
+  <meta property="og:image:secure_url" content="{{ $urlString }}"/>
+  <meta property="og:image:width" content="1200"/>
+  <meta property="og:image:height" content="630"/>
+  <meta name="twitter:image:src" content="{{ $urlString }}"/> 
   {{- else -}}
   <meta property="og:image" content="{{ "og-image-1200x630.png" | relURL }}"/>
   <meta property="og:image:secure_url" content="{{ "og-image-1200x630.png" | absURL }}"/>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -252,10 +252,10 @@
       {{ $img := partial "helpers/get-image" .logo }}
       <!-- check if this is png or jpeg and resize if it is -->
       {{ if or (eq $img.MediaType.SubType "png") (eq $img.MediaType.SubType "jpeg")}}
-      {{ $onex := $img.Resize (printf "%dx" .width) }}
-      {{ $twox := $img.Resize (printf "%dx" (mul .width 2)) }}
-      <img srcset="{{$onex.RelPermalink}} 1x, {{$twox.RelPermalink}} 2x" src="{{$onex.RelPermalink}}" alt="{{.alt}}"
-        width="{{$onex.Width}}" height="{{$onex.Height}}">
+      <img srcset="
+        {{$img.RelPermalink}}?nf_resize=fit&w={{.width}} 1x,
+        {{$img.RelPermalink}}?nf_resize=fit&w={{(mul .width 2)}} 2x"
+        src="{{$img.RelPermalink}}" alt="{{.alt}}" width="{{.width}}" {{with .height}} height="{{.}}"{{end}}>
       <!-- if some other type (like svg), just output directly -->
       {{ else }}
       <img src="{{$img.RelPermalink}}" alt="{{.alt}}" width="{{.width}}"{{with .height}} height="{{.}}"{{end}}>

--- a/layouts/_default/loop54.json
+++ b/layouts/_default/loop54.json
@@ -11,7 +11,7 @@
   {{- end -}}
   {{- $image := false -}}
   {{- with .Resources.ByType "image" -}}
-  {{- $image = (index . 0).Resize "375x" -}}
+  {{- $image = printf "%s%s" (index . 0) "?nf_resize=fit&w=375" -}}
   {{- end -}}
   {{- $totalVariants := float (len .Params.variants) -}}
   {{- $availableVariants := len (where .Params.variants "available" true) -}}
@@ -29,11 +29,11 @@
     "Url": "{{.Permalink}}",
     "Description": "{{.Params.description}}",
     "Brand": "Reima",
-    "ImageURL": "{{with $image}}{{.Permalink}}{{end}}",
+    "ImageURL": "{{if $image}}{{.Permalink}}{{$image}}{{end}}",
     {{- with $image }}
     "ImageDimensions": {
-      "Width": {{.Width}},
-      "Height": {{.Height}}
+      "Width": 375,
+      "Height": 540
     },
     {{- end }}
     "Attributes": {{ .Params.filtering | jsonify }},

--- a/layouts/partials/carousel.html
+++ b/layouts/partials/carousel.html
@@ -13,7 +13,7 @@
             {{- with $slide.image }}
             {{- with partial "helpers/get-image" . }}
             {{- $params := (dict "image" . "widths" "375,768,1080") }}
-            {{- $default := .Resize "1080x" -}}
+            {{- $default := . -}}
             <picture>
                 <!-- difficult to work out sizes... -->
                 {{ $sizes := "min(50vw, 650px)" }}
@@ -24,10 +24,10 @@
                 <img
                     src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 {{.Width}} {{.Height}}'%3E%3C/svg%3E"
                     class="lazyload" loading="lazy" alt="{{$alt}}" data-srcset="{{partial "srcset" $params}}"
-                    data-src="{{$default.RelPermalink}}" sizes="(min-width: 768px) {{$sizes}}, 100vw" />
+                    data-src="{{$default.RelPermalink}}?nf_resize=fit&w=1080" sizes="(min-width: 768px) {{$sizes}}, 100vw" />
             </picture>
             <noscript>
-                <img loading="lazy" alt="{{$alt}}" srcset="{{partial "srcset" $params}}" src="{{$default.RelPermalink}}" height="{{.Height}}"
+                <img loading="lazy" alt="{{$alt}}" srcset="{{partial "srcset" $params}}" src="{{$default.RelPermalink}}?nf_resize=fit&w=1080" height="{{.Height}}"
                 width="{{.Width}}" />
             </noscript>
             {{ end }}

--- a/layouts/partials/elements/benefits.html
+++ b/layouts/partials/elements/benefits.html
@@ -15,7 +15,7 @@
         <img srcset="
           {{$img.RelPermalink}}?nf_resize=fit&w={{.width}} 1x,
           {{$img.RelPermalink}}?nf_resize=fit&w={{(mul .width 2)}} 2x"
-          src="{{$onex.RelPermalink}}" alt="{{$alt}}"
+          src="{{$img.RelPermalink}}" alt="{{$alt}}"
           width="{{.width}}" {{with .height}} height="{{.}}"{{end}}>
         <!-- if some other type (like svg), just output directly -->
         {{- else }}

--- a/layouts/partials/elements/benefits.html
+++ b/layouts/partials/elements/benefits.html
@@ -12,10 +12,11 @@
         {{- $img := partial "helpers/get-image" .icon }}
         <!-- check if this is png or jpeg and resize if it is -->
         {{- if or (eq $img.MediaType.SubType "png") (eq $img.MediaType.SubType "jpeg")}}
-        {{- $onex := $img.Resize (printf "%dx" .width) }}
-        {{- $twox := $img.Resize (printf "%dx" (mul .width 2)) }}
-        <img srcset="{{$onex.RelPermalink}} 1x, {{$twox.RelPermalink}} 2x" src="{{$onex.RelPermalink}}" alt="{{$alt}}"
-             width="{{$onex.Width}}" height="{{$onex.Height}}">
+        <img srcset="
+          {{$img.RelPermalink}}?nf_resize=fit&w={{.width}} 1x,
+          {{$img.RelPermalink}}?nf_resize=fit&w={{(mul .width 2)}} 2x"
+          src="{{$onex.RelPermalink}}" alt="{{$alt}}"
+          width="{{.width}}" {{with .height}} height="{{.}}"{{end}}>
         <!-- if some other type (like svg), just output directly -->
         {{- else }}
         <img src="{{$img.RelPermalink}}" alt="{{$alt}}" width="{{.width}}"{{with .height}} height="{{.}}"{{end}}>

--- a/layouts/partials/image.html
+++ b/layouts/partials/image.html
@@ -30,17 +30,18 @@
 {{- end}}
 
 {{- $width := index (split $.widths ",") 0 -}}
-{{- $default := .image.Resize (printf "%sx" $width) -}}
+
+{{- $default := .image }}
 {{- if not .sizes }}
 {{- warnf "`sizes` attribute missing for image %s" .image.RelPermalink }}
 {{- end }}
 
 <img
   src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 {{$default.Width}} {{$default.Height}}'%3E%3C/svg%3E"
-  loading="lazy" data-srcset="{{partial "srcset" $}}" data-src="{{$default.RelPermalink}}" height="{{.image.Height}}"
+  loading="lazy" data-srcset="{{partial "srcset" $}}" data-src="{{$default.RelPermalink}}?nf_resize=fit&w={{$width}}" height="{{.image.Height}}"
   width="{{.image.Width}}" class="lazyload {{.class}}" {{with .sizes}}sizes="{{.}}" {{end}} alt="{{$alt}}"
   {{range $key, $val := .dataset}}data-{{$key}}="{{$val}}" {{end}} />
 <noscript>
-  <img loading="lazy" srcset="{{partial "srcset" $}}" src="{{$default.RelPermalink}}" height="{{.image.Height}}"
+  <img loading="lazy" srcset="{{partial "srcset" $}}" src="{{$default.RelPermalink}}?nf_resize=fit&w={{$width}}" height="{{.image.Height}}"
     width="{{.image.Width}}" class="{{.class}}" {{with .sizes}}sizes="{{.}}" {{end}} alt="{{$alt}}" />
 </noscript>

--- a/layouts/partials/modules/hero.html
+++ b/layouts/partials/modules/hero.html
@@ -82,7 +82,7 @@
   {{- with .image }}
   {{- with partial "helpers/get-image" . }}
   {{- $params := (dict "image" . "widths" "2160,1080,768") }}
-  {{- $default := .Resize "1080x" -}}
+  {{- $default := . -}}
   <picture>
     <!--
       Regarding `sizes`:
@@ -95,17 +95,17 @@
     <source {{if $lazyload}}data-{{end -}}srcset="{{partial "srcset" (dict "image" . "widths" "1080,768")}}">
     {{- else }}
     <source {{if $lazyload}}data-{{end -}}srcset="
-      {{- (.Fill "375x375").RelPermalink}} 375w,
-      {{- (.Fill "750x750").RelPermalink}} 750w,
-      {{- (.Fill "1080x1080").RelPermalink}} 1080w,
-      {{- (.Fill "1500x1500").RelPermalink}} 1500w">
+      {{- .RelPermalink}}?nf_resize=fit&w=375&h=375 375w,
+      {{- .RelPermalink}}?nf_resize=fit&w=750&h=750 750w,
+      {{- .RelPermalink}}?nf_resize=fit&w=1080&h=1080 1080w,
+      {{- .RelPermalink}}?nf_resize=fit&w=1500&h=1500 1500w">
     {{- end }}
     <img class="lazyload" {{if $lazyload}} loading="lazy"
       srcset="data:image/svg+xml,<svg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20{{$default.Width}}%20{{$default.Height}}'></svg>"
-      {{end}} src="{{$default.RelPermalink}}" width="{{.Width}}" height="{{.Height}}" alt="{{$alt}}" />
+      {{end}} src="{{$default.RelPermalink}}?nf_resize=fit&w=1080" width="{{.Width}}" height="{{.Height}}" alt="{{$alt}}" />
   </picture>
   <noscript>
-    <img {{if $lazyload}}loading="lazy" {{end}} srcset="{{partial "srcset" $params}}" src="{{$default.RelPermalink}}"
+    <img {{if $lazyload}}loading="lazy" {{end}} srcset="{{partial "srcset" $params}}" src="{{$default.RelPermalink}}?nf_resize=fit&w=1080"
       height="{{.Height}}" width="{{.Width}}" alt="{{$alt}}"/>
   </noscript>
   {{- end }}

--- a/layouts/partials/modules/image-links.html
+++ b/layouts/partials/modules/image-links.html
@@ -31,7 +31,7 @@
       {{- with .image }}
       {{- with partial "helpers/get-image" . }}
       {{- $params := (dict "image" . "widths" "375,768,1080") }}
-      {{- $default := .Resize "1080x" -}}
+      {{- $default := . -}}
       <picture>
         <!-- difficult to work out sizes... -->
         {{ $sizes := "min(50vw, 650px)" }}
@@ -42,10 +42,10 @@
         <img
           src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 {{.Width}} {{.Height}}'%3E%3C/svg%3E"
           class="lazyload" loading="lazy" data-srcset="{{partial "srcset" $params}}"
-          data-src="{{$default.RelPermalink}}" sizes="(min-width: 768px) {{$sizes}}, 100vw" alt="{{$alt}}" />
+          data-src="{{$default.RelPermalink}}?nf_resize=fit&w=1080" sizes="(min-width: 768px) {{$sizes}}, 100vw" alt="{{$alt}}" />
       </picture>
       <noscript>
-        <img loading="lazy" srcset="{{partial "srcset" $params}}" src="{{$default.RelPermalink}}" height="{{.Height}}"
+        <img loading="lazy" srcset="{{partial "srcset" $params}}" src="{{$default.RelPermalink}}?nf_resize=fit&w=1080" height="{{.Height}}"
           width="{{.Width}}" alt="{{$alt}}" />
       </noscript>
       {{ end }}

--- a/layouts/partials/modules/milestones.html
+++ b/layouts/partials/modules/milestones.html
@@ -9,13 +9,13 @@
                 <div class="milestones__media-left">
                     <div class="milestones__about-timeline-img">
                         {{- with partial "helpers/get-image" .image }}
-                            <img class="lazyload" loading="lazy"
-                            data-srcset="{{(.Fill "70x70").RelPermalink}} 70w,
-                            {{(.Fill "140x140").RelPermalink}} 140w,
-                            {{(.Fill "100x100").RelPermalink}} 100w,
-                            {{(.Fill "200x200").RelPermalink}} 200w"
-                            sizes="(min-width: 768px) 100px, 70px"
-                            data-src="{{(.Fill "100x100").RelPermalink}}" alt="{{$alt}}" />
+                            <img class="lazyload" loading="lazy" data-srcset="
+                                {{- .RelPermalink}}?nf_resize=smartcrop&w=70&h=70 70w,
+                                {{- .RelPermalink}}?nf_resize=smartcrop&w=140&h=140 140w,
+                                {{- .RelPermalink}}?nf_resize=smartcrop&w=100&h=100 100w,
+                                {{- .RelPermalink}}?nf_resize=smartcrop&w=200&h=200 200w"
+                                sizes="(min-width: 768px) 100px, 70px"
+                                data-src="{{.RelPermalink}}?nf_resize=smartcrop&w=100&h=100" alt="{{$alt}}" />
                         {{ end }}
                     </div>
                 </div>

--- a/layouts/partials/modules/testimonials.html
+++ b/layouts/partials/modules/testimonials.html
@@ -2,13 +2,13 @@
 {{- define "partials/testimonials-image" }}
 {{- with partial "helpers/get-image" . }}
 <figure>
-  <img class="lazyload testimonials-image" loading="lazy"
-    data-srcset="{{(.Fill "70x70").RelPermalink}} 70w,
-    {{(.Fill "140x140").RelPermalink}} 140w,
-    {{(.Fill "100x100").RelPermalink}} 100w,
-    {{(.Fill "200x200").RelPermalink}} 200w"
+  <img class="lazyload testimonials-image" loading="lazy" data-srcset="
+    {{- .RelPermalink}}?nf_resize=smartcrop&w=70&h=70 70w,
+    {{- .RelPermalink}}?nf_resize=smartcrop&w=140&h=140 140w,
+    {{- .RelPermalink}}?nf_resize=smartcrop&w=100&h=100 100w,
+    {{- .RelPermalink}}?nf_resize=smartcrop&w=200&h=200 200w"
     sizes="(min-width: 768px) 100px, 70px"
-    data-src="{{(.Fill "100x100").RelPermalink}}" alt="" />
+    data-src="{{.RelPermalink}}?nf_resize=smartcrop&w=100&h=100" alt="" />
 </figure>
 {{- end }}
 {{- end }}

--- a/layouts/partials/product.html
+++ b/layouts/partials/product.html
@@ -56,7 +56,7 @@
         {{- with .Params.alt }}
         {{- $alt = . }}
         {{- end }}
-        <img srcset="{{partial "srcset" (dict "image" . "widths" "375,750")}}" src="{{(.Resize "375x").RelPermalink}}"
+        <img srcset="{{partial "srcset" (dict "image" . "widths" "375,750")}}" src="{{.RelPermalink}}?nf_resize=fit&w=375"
           height="{{.Height}}" width="{{.Width}}" sizes="{{$sizes}}" data-path="{{.Name}}" alt="{{$alt}}" />
         {{- end }}
         {{- range $i, $img := after 1 $imgs }}
@@ -448,7 +448,7 @@
   {{- with .Resources.ByType "image" }}
   {{- with index . 0 }}
   "image": [
-    "{{(.Resize "800x").Permalink}}"
+    "{{.Permalink}}?nf_resize=fit&w=800"
   ],
   {{- end }}
   {{- end }}

--- a/layouts/partials/srcset.html
+++ b/layouts/partials/srcset.html
@@ -21,6 +21,6 @@
 {{- end -}}
 {{- $len := len $widths -}}
 {{- range $i, $w := $widths -}}
-{{($.image.Resize (printf "%sx%s" $w $params)).RelPermalink}} {{$w}}w{{if ne (add $i 1) $len}}, {{end}}
+{{$.image.RelPermalink}}?nf_resize=fit&w={{(printf "%s%s" $w $params)}} {{$w}}w{{if ne (add $i 1) $len}}, {{end}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
## Why
We need to move from Git LFS to a Netlify Large Media (NLM) solution to store our images because Forestry stopped working with it

## How
Image processing done by Hugo is cleaned away because the images will be stored in a cdn (and not work) and Netlify Image Transforms are added in their place in the frontend to process images

[](https://docs.netlify.com/large-media/transform-images/)


